### PR TITLE
Validate that package name contains a namespace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 
 ### Bug fixes:
 
-- Fix issue with Welcome Screen display [@ericof] 
+- Fix issue with Welcome Screen display [@ericof]
 
 ## 0.7.0 (2024-05-27)
 

--- a/cookieplone/utils/validators.py
+++ b/cookieplone/utils/validators.py
@@ -51,18 +51,15 @@ def validate_language_code(value: str) -> str:
 
 def validate_python_package_name(value: str) -> str:
     """Validate python_package_name is an identifier."""
-    status = False
-    if value.count(".") != 1:
+    parts = value.split(".")
+    if any(not part.isidentifier() for part in parts):
+        return f"'{value}' is not a valid Python identifier."
+    if len(parts) != 2:
         return (
             "The Python package name must contain a single namespace "
             "(e.g. collective.something)"
         )
-    if "." in value:
-        namespace, package = value.split(".")
-        status = namespace.isidentifier() and package.isidentifier()
-    else:
-        status = value.isidentifier()
-    return "" if status else f"'{value}' is not a valid Python identifier."
+    return ""
 
 
 def validate_hostname(value: str) -> str:

--- a/cookieplone/utils/validators.py
+++ b/cookieplone/utils/validators.py
@@ -52,6 +52,11 @@ def validate_language_code(value: str) -> str:
 def validate_python_package_name(value: str) -> str:
     """Validate python_package_name is an identifier."""
     status = False
+    if value.count(".") != 1:
+        return (
+            "The Python package name must contain a single namespace "
+            "(e.g. collective.something)"
+        )
     if "." in value:
         namespace, package = value.split(".")
         status = namespace.isidentifier() and package.isidentifier()

--- a/news/36.bugfix
+++ b/news/36.bugfix
@@ -1,0 +1,1 @@
+Show a more helpful error message if user enters a Python package name without a namespace. @davisagli

--- a/tests/utils/test_validators.py
+++ b/tests/utils/test_validators.py
@@ -73,10 +73,22 @@ def test_validate_language_code(value: str, expected: str):
         (" ", "' ' is not a valid Python identifier."),
         ("", "'' is not a valid Python identifier."),
         ("project title", "'project title' is not a valid Python identifier."),
-        ("project_title", ""),
+        (
+            "project_title",
+            "The Python package name must contain a single namespace "
+            "(e.g. collective.something)",
+        ),
         ("project-title", "'project-title' is not a valid Python identifier."),
-        ("projecttitle", ""),
-        ("projectTitle", ""),
+        (
+            "projecttitle",
+            "The Python package name must contain a single namespace "
+            "(e.g. collective.something)",
+        ),
+        (
+            "projectTitle",
+            "The Python package name must contain a single namespace "
+            "(e.g. collective.something)",
+        ),
         ("project.title", ""),
     ),
 )


### PR DESCRIPTION
Fixes #34 by returning a validation error instead of an exception.

It would be nice to actually support package names with no namespace or multiple namespaces, but because of how the templates are constructed, that's quite a bit more work.