### PR TITLE
Fix replay without explicit replay file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 
 ### Bug fixes:
 
-- Fix issue with Welcome Screen display [@ericof] 
+- Fix issue with Welcome Screen display [@ericof]
 
 ## 0.7.0 (2024-05-27)
 

--- a/cookieplone/cli.py
+++ b/cookieplone/cli.py
@@ -151,7 +151,7 @@ def cli(
     if replay_file and replay_file.exists():
         # Use replay_file
         replay = replay_file
-    else:
+    elif not replay:
         # Annotate extra_context
         extra_context = parse_extra_content(extra_context)
         extra_context["__generator_signature"] = internal.signature_md(repo_path)

--- a/news/37.bugfix
+++ b/news/37.bugfix
@@ -1,0 +1,1 @@
+Fix error with `--replay`. @davisagli


### PR DESCRIPTION
Fixes #35 

(It would be nice to also avoid prompting the user for which template to run when doing a replay, but I didn't try to solve that.)