### PR TITLE
Remove documentation as a template from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </div>
 
 Welcome to Cookieplone, a powerful wrapper around Cookiecutter designed to streamline the development of Plone codebases.
-Whether you're building a backend add-on, a new Volto add-on, a full project with both backend and frontend, or even documentation, Cookieplone simplifies the process using robust Cookiecutter templates.
+Whether you're building a backend add-on, a new Volto add-on, a full project with both backend and frontend, Cookieplone simplifies the process using robust Cookiecutter templates.
 
 ## Key features 🌟
 


### PR DESCRIPTION
We don't have a template for documentation at this time. We can add it back when we do.

See https://github.com/plone/documentation/pull/1714#discussion_r1779724997