### PR TITLE
Add options to avoid prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ pipx run cookieplone
 
 Cookieplone will walk you through the necessary steps, using sensible defaults and offering customization options where needed.
 
+### Use options to avoid prompts
+
+The cookiecutter will ask a lot of questions.
+You can use some of its options to avoid repeatedly entering the same values.
+
+#### `--no-input`
+
+You can use the [`--no-input`](https://cookiecutter.readthedocs.io/en/latest/cli_options.html#cmdoption-cookiecutter-no-input) option to make the cookiecutter not prompt for parameters and only use `cookiecutter.json` file content.
+
+#### `--replay` and `--replay-file`
+
+You can use the options [`--replay`](https://cookiecutter.readthedocs.io/en/latest/cli_options.html#cmdoption-cookiecutter-replay) and [`--replay-file`](https://cookiecutter.readthedocs.io/en/latest/cli_options.html#cmdoption-cookiecutter-replay-file) to not prompt for parameters and only use information entered previously or from a specified file.
+See [Replay Project Generation](https://cookiecutter.readthedocs.io/en/latest/advanced/replay.html) in the cookiecutter documentation for more information.
+
 ### Specify a template
 
 You can also specify other templates.

--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ Cookieplone will walk you through the necessary steps, using sensible defaults a
 
 ### Use options to avoid prompts
 
-The cookiecutter will ask a lot of questions.
+Cookieplone will ask a lot of questions.
 You can use some of its options to avoid repeatedly entering the same values.
 
 #### `--no-input`
 
-You can use the [`--no-input`](https://cookiecutter.readthedocs.io/en/latest/cli_options.html#cmdoption-cookiecutter-no-input) option to make the cookiecutter not prompt for parameters and only use `cookiecutter.json` file content.
+You can use the [`--no-input`](https://cookiecutter.readthedocs.io/en/latest/cli_options.html#cmdoption-cookiecutter-no-input) option to make Cookieplone not prompt for parameters and only use `cookiecutter.json` file content.
 
 #### `--replay` and `--replay-file`
 

--- a/cookieplone/cli.py
+++ b/cookieplone/cli.py
@@ -70,7 +70,7 @@ def cli(
     no_input: Annotated[
         bool,
         typer.Option(
-            "--no_input",
+            "--no-input",
             help=(
                 "Do not prompt for parameters and only use cookiecutter.json "
                 "file content. Defaults to deleting any cached resources and "

--- a/news/41.bugfix
+++ b/news/41.bugfix
@@ -1,0 +1,1 @@
+Rename the `--no_input` option to `--no-input` for consistency with other options. @davisagli


### PR DESCRIPTION
Source: https://github.com/collective/cookiecutter-plone-starter/?tab=readme-ov-file#use-options-to-avoid-prompts