### PR TITLE
Change default initial branch to match github

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ Install all development dependencies, including Hatch, and create a local virtua
 make install
 ```
 
+### Run the checked out branch of Cookieplone
+
+```shell
+hatch run cookieplone
+```
+
 ### Check and format the codebase
 
 ```shell

--- a/cookieplone/utils/git.py
+++ b/cookieplone/utils/git.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: MIT
 from pathlib import Path
 
-from git import Commit, Repo
-from git.exc import InvalidGitRepositoryError
+from git import Commit, Git, Repo
+from git.exc import GitCommandError, InvalidGitRepositoryError
 
 
 def repo_from_path(path: Path) -> Repo | None:
@@ -24,7 +24,11 @@ def check_path_is_repository(path: Path) -> bool:
 def initialize_repository(path: Path) -> Repo:
     """Initialize a git repository and add all files."""
     if not check_path_is_repository(path):
-        repo = Repo.init(path)
+        try:
+            initial_branch = Git().config("init.defaultBranch")
+        except GitCommandError:
+            initial_branch = "main"
+        repo = Repo.init(path, initial_branch=initial_branch)
         repo.git.add(path)
     else:
         repo = Repo(path)

--- a/news/135.bugfix
+++ b/news/135.bugfix
@@ -1,0 +1,2 @@
+Use `main` as the default branch for new git repositories, unless it has been
+customized via the `init.defaultBranch` setting in git config. @davisagli

--- a/tests/utils/test_git.py
+++ b/tests/utils/test_git.py
@@ -29,6 +29,7 @@ def test_initialize_repository_existing_repo(tmp_repo):
 def test_initialize_repository_new_repo(no_repo):
     repo = git.initialize_repository(no_repo)
     assert isinstance(repo, Repo)
+    assert repo.active_branch.name == "main"
 
 
 def test_get_last_commit(tmp_repo):


### PR DESCRIPTION
Fixes #59

Tested on my machine with and without `init.defaultBranch` set in ~/.gitconfig