### PR TITLE
Add filters as_major_minor, package_namespace_path

### DIFF
--- a/cookieplone/cli.py
+++ b/cookieplone/cli.py
@@ -31,7 +31,7 @@ def validate_extra_context(value: list[str] | None = None) -> list[str]:
     return value
 
 
-def parse_extra_content(value: list[str]) -> dict:
+def parse_extra_context(value: list[str]) -> dict:
     """Parse extra content and return a dictionary with options."""
     if not value:
         return {}
@@ -151,17 +151,20 @@ def cli(
     if not output_dir:
         output_dir = Path().cwd()
 
+    # Annotate extra_context
+    ## We do this to always get the latest information about the repository
+    ## and template being used
+    extra_context = parse_extra_context(extra_context)
+    extra_context["__generator_sha"] = internal.repo_sha(repo_path)
+    extra_context["__generator_signature"] = internal.signature_md(repo_path)
+    extra_context["__cookieplone_repository_path"] = f"{repo_path}"
+    extra_context["__cookieplone_template"] = f"{template}"
+
     replay_file = files.resolve_path(replay_file) if replay_file else replay_file
     if replay_file and replay_file.exists():
         # Use replay_file
         replay = replay_file
-    elif not replay:
-        # Annotate extra_context
-        extra_context = parse_extra_content(extra_context)
-        extra_context["__generator_sha"] = internal.repo_sha(repo_path)
-        extra_context["__generator_signature"] = internal.signature_md(repo_path)
-        extra_context["__cookieplone_repository_path"] = f"{repo_path}"
-        extra_context["__cookieplone_template"] = f"{template}"
+
     # Run generator
     try:
         generate(

--- a/cookieplone/filters/__init__.py
+++ b/cookieplone/filters/__init__.py
@@ -36,6 +36,13 @@ def package_namespaces(v) -> str:
 
 
 @simple_filter
+def package_namespace_path(v: str) -> str:
+    """Return path to the package namespace including the src directory."""
+    top_namespace = v.split(".")[0]
+    return f"src/{top_namespace}"
+
+
+@simple_filter
 def package_path(v) -> str:
     """Return path to the package code within the src directory."""
     return "/".join(v.split("."))
@@ -139,3 +146,9 @@ def as_semver(v: str) -> str:
 def unscoped_package_name(v: str) -> str:
     """Return the unscoped name for a given package."""
     return npm.unscoped_package_name(v)
+
+
+@simple_filter
+def as_major_minor(v: str) -> str:
+    """Return a version in the major.minor format."""
+    return versions.format_as_major_minor(v)

--- a/cookieplone/utils/versions.py
+++ b/cookieplone/utils/versions.py
@@ -145,3 +145,12 @@ def python_version_for_plone(plone_version: str) -> str:
     """Return the latest supported Python version for a given Plone version."""
     version_support = python_versions_for_plone(plone_version)
     return version_support.latest
+
+
+def format_as_major_minor(version: str) -> str:
+    """Format a list of versions as major.minor."""
+    # Handle "versions" used in tests / constraints
+    if "-" in version:
+        version = version.split("-")[0]
+    v = Version(version)
+    return f"{v.major}.{v.minor}"

--- a/news/+as_major_minor.feature
+++ b/news/+as_major_minor.feature
@@ -1,0 +1,1 @@
+Add `as_major_minor` filter. @ericof

--- a/news/+extra_context.feature
+++ b/news/+extra_context.feature
@@ -1,0 +1,1 @@
+Parse extra-context information even if we are running with a replay file. @ericof

--- a/news/+package_namespace_path.feature
+++ b/news/+package_namespace_path.feature
@@ -1,0 +1,1 @@
+Add `package_namespace_path` filter. @ericof

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,8 +12,8 @@ from cookieplone import cli
         (["foo=1", "bar=2"], {"foo": "1", "bar": "2"}),
     ],
 )
-def test_parse_extra_content(value: list[str], expected: dict):
-    func = cli.parse_extra_content
+def test_parse_extra_context(value: list[str], expected: dict):
+    func = cli.parse_extra_context
     assert func(value) == expected
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -74,6 +74,26 @@ def generate_context_file(tmp_path):
             "{{'@plone/volto' | unscoped_package_name}}",
             "volto",
         ],
+        ["as_major_minor", "{{'1.0.0a0' | as_major_minor}}", "1.0"],
+        ["as_major_minor", "{{'6.1.1rc1' | as_major_minor}}", "6.1"],
+        ["as_major_minor", "{{'1' | as_major_minor}}", "1.0"],
+        ["package_namespace_path", "{{'foo' | package_namespace_path}}", "src/foo"],
+        ["package_namespace_path", "{{'foo.bar' | package_namespace_path}}", "src/foo"],
+        [
+            "package_namespace_path",
+            "{{'foo.bar.foobar' | package_namespace_path}}",
+            "src/foo",
+        ],
+        [
+            "package_namespace_path",
+            "{{'collective.addon' | package_namespace_path}}",
+            "src/collective",
+        ],
+        [
+            "package_namespace_path",
+            "{{'collective_addon' | package_namespace_path}}",
+            "src/collective_addon",
+        ],
     ],
 )
 def test_filters(generate_context_file, filter_: str, raw: str, expected: str):

--- a/tests/utils/test_versions.py
+++ b/tests/utils/test_versions.py
@@ -275,3 +275,25 @@ def test_convert_pep440_semver(pep440: str, expected: str):
     func = versions.convert_pep440_semver
     result = func(pep440)
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        ["1.0.0a0", "1.0"],
+        ["1.0.0b1", "1.0"],
+        ["1.0.0rc1", "1.0"],
+        ["1.0.0rc1.dev0", "1.0"],
+        ["1.0.0", "1.0"],
+        ["6.1.1.dev0", "6.1"],
+        ["6.1.1.post0", "6.1"],
+        ["6.1-dev", "6.1"],
+        ["6.1-latest", "6.1"],
+        ["202503.1", "202503.1"],
+        ["202512.1", "202512.1"],
+    ],
+)
+def test_format_as_major_minor(version: str, expected: str):
+    func = versions.format_as_major_minor
+    result = func(version)
+    assert result == expected


### PR DESCRIPTION
# Filters
- `as_major_minor`
- `package_namespace_path`

# Refactor
- Cli now always parses and populate extra_context