### PR TITLE
Fix check of prerelease versions

### DIFF
--- a/cookieplone/filters/__init__.py
+++ b/cookieplone/filters/__init__.py
@@ -63,15 +63,19 @@ def extract_host(hostname: str) -> str:
 
 
 @simple_filter
-def use_prerelease_versions(_: str) -> str:
+def use_prerelease_versions(use_prerelease: str) -> str:
     """Should we use prerelease versions of packages."""
-    use_prerelease_versions = "USE_PRERELEASE" in os.environ
-    return "Yes" if use_prerelease_versions else "No"
+    use_prerelease_versions_check = "USE_PRERELEASE" in os.environ or parse_boolean(
+        use_prerelease
+    )
+    return "Yes" if use_prerelease_versions_check else "No"
 
 
 @simple_filter
 def latest_volto(use_prerelease_versions: str) -> str:
     """Return the latest released version of Volto."""
+    import pdb; pdb.set_trace(); a=1
+
     allow_prerelease = parse_boolean(use_prerelease_versions)
     return versions.latest_volto(allow_prerelease=allow_prerelease)
 

--- a/cookieplone/filters/__init__.py
+++ b/cookieplone/filters/__init__.py
@@ -74,8 +74,6 @@ def use_prerelease_versions(use_prerelease: str) -> str:
 @simple_filter
 def latest_volto(use_prerelease_versions: str) -> str:
     """Return the latest released version of Volto."""
-    import pdb; pdb.set_trace(); a=1
-
     allow_prerelease = parse_boolean(use_prerelease_versions)
     return versions.latest_volto(allow_prerelease=allow_prerelease)
 

--- a/news/98.bugfix
+++ b/news/98.bugfix
@@ -1,0 +1,1 @@
+Fix check of prerelease versions @erral

--- a/tests/utils/test_versions.py
+++ b/tests/utils/test_versions.py
@@ -129,6 +129,8 @@ def mock_pypi_packages(monkeypatch, plone_versions):
         ["18.0.0-alpha.27", "17", None, True, True],
         ["18.0.0-alpha.27", "17", "18", True, True],
         ["18.0.0-alpha.27", "17", "17.99", True, False],
+        ["19.0.0-alpha.0", "17", None, False, False],
+        ["19.0.0-alpha.0", "17", None, True, True],
     ],
 )
 def test_is_valid_version(


### PR DESCRIPTION
The check function was only checking the environment var and not the user-entered preference.

I have kept the environment var override.

Fixes #98 