### PR TITLE
Audit and simplify exception handling in generator module

### DIFF
--- a/cookieplone/generator/__init__.py
+++ b/cookieplone/generator/__init__.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-import json
 from collections import OrderedDict
 from pathlib import Path
 
@@ -13,7 +12,6 @@ from cookieplone.config import Answers, CookieploneState, generate_state
 from cookieplone.exceptions import (
     FailedHookException,
     GeneratorException,
-    PreFlightException,
     RepositoryException,
 )
 from cookieplone.generator.main import cookieplone
@@ -65,6 +63,10 @@ def generate(config: GenerateConfig) -> Path:
         )
         raise exc.InvalidModeException(err_msg)
 
+    # Resolve the template repository.
+    # RepositoryException and FailedHookException are normalised into a
+    # single RepositoryException so callers only need one handler.
+    # PreFlightException (from pre-prompt hooks) propagates unchanged.
     try:
         repository_info = get_repository(
             config.repository,
@@ -78,10 +80,7 @@ def generate(config: GenerateConfig) -> Path:
             config.default_config,
         )
     except (RepositoryException, FailedHookException) as e:
-        raise RepositoryException() from e
-    except PreFlightException as e:
-        # Validation check
-        raise e
+        raise RepositoryException(str(e)) from e
 
     repo_dir = repository_info.repo_dir
 
@@ -102,6 +101,10 @@ def generate(config: GenerateConfig) -> Path:
 
     run_config = config.to_run_config()
     dump_location = None
+    # Run the template wizard and render files.
+    # cookieplone() (in main.py) already converts cookiecutter-level
+    # exceptions into GeneratorException, so we only re-raise those.
+    # The ``except Exception`` is a safety net for anything unexpected.
     try:
         result = cookieplone(
             state=state,
@@ -111,13 +114,6 @@ def generate(config: GenerateConfig) -> Path:
         dump_location = result
     except GeneratorException:
         raise
-    except exc.UndefinedVariableInTemplate as undefined_err:
-        context_str = json.dumps(undefined_err.context, indent=2, sort_keys=True)
-        msg = f"""{undefined_err.message}
-        Error message: {undefined_err.error.message}
-        Context: {context_str}
-        """
-        raise GeneratorException(message=msg, state=state, original=undefined_err)  # noQA:B904
     except Exception as e:
         raise GeneratorException(message=str(e), state=state, original=e)  # noQA:B904
     else:

--- a/news/147.bugfix
+++ b/news/147.bugfix
@@ -1,0 +1,1 @@
+Fixed ``RepositoryException`` losing its error message and removed dead exception handlers in the generator module. @ericof

--- a/tests/generator/test_generate.py
+++ b/tests/generator/test_generate.py
@@ -29,10 +29,10 @@ def test_replay_with_extra_context_raises(generate_config):
 
 
 def test_repository_exception_reraised(mock_get_repository, generate_config):
-    """RepositoryException from get_repository is re-raised."""
+    """RepositoryException from get_repository preserves the original message."""
     mock_get_repository.side_effect = RepositoryException("not found")
     config = replace(generate_config, no_input=False)
-    with pytest.raises(RepositoryException):
+    with pytest.raises(RepositoryException, match="not found"):
         generate(config)
 
 

--- a/tests/generator/test_generate_full.py
+++ b/tests/generator/test_generate_full.py
@@ -1,10 +1,8 @@
 """Tests for the generate() happy path and exception handling in __init__.py."""
 
 from dataclasses import replace
-from unittest.mock import MagicMock
 
 import pytest
-from cookiecutter import exceptions as cc_exc
 
 from cookieplone.exceptions import GeneratorException
 from cookieplone.generator import generate
@@ -104,33 +102,6 @@ def test_skips_dump_when_disabled(
     mock_dump_replay.assert_not_called()
 
 
-def test_wraps_undefined_variable(
-    mock_get_repository,
-    mock_load_replay,
-    mock_generate_state,
-    mock_cookieplone_entry,
-    mock_write_answers,
-    mock_dump_replay,
-    repository_info_with_config,
-    generate_config,
-    tmp_path,
-):
-    """generate wraps UndefinedVariableInTemplate in GeneratorException."""
-    mock_get_repository.return_value = repository_info_with_config
-    inner_error = MagicMock()
-    inner_error.message = "original error"
-    err = cc_exc.UndefinedVariableInTemplate(
-        "undefined var", inner_error, {"key": "val"}
-    )
-    mock_cookieplone_entry.side_effect = err
-    mock_write_answers.return_value = tmp_path / "answers.json"
-
-    config = replace(generate_config, dump_answers=False)
-    with pytest.raises(GeneratorException) as exc_info:
-        generate(config)
-    assert "undefined var" in exc_info.value.message
-
-
 def test_wraps_generic_exception(
     mock_get_repository,
     mock_load_replay,
@@ -215,5 +186,5 @@ def test_failed_hook_reraised_as_repository_exception(
     from cookieplone.exceptions import FailedHookException, RepositoryException
 
     mock_get_repository.side_effect = FailedHookException("hook fail")
-    with pytest.raises(RepositoryException):
+    with pytest.raises(RepositoryException, match="hook fail"):
         generate(generate_config)


### PR DESCRIPTION
## Summary

Audits and simplifies exception handling in `generator/__init__.py` as described in #147.

- **Fixed `RepositoryException` losing its message**: `raise RepositoryException()` replaced with `raise RepositoryException(str(e))` so the original error is preserved
- **Removed dead `UndefinedVariableInTemplate` handler**: `main.py` already catches this and wraps it in `GeneratorException` — the handler in `__init__.py` was unreachable
- **Removed no-op `PreFlightException` handler**: the catch-and-reraise was a no-op; the exception now propagates naturally
- **Added inline comments** documenting the exception layering between `__init__.py` and `main.py`

Closes #147

## Test plan

- [x] All existing tests pass (616 — one dead-code test removed)
- [x] `test_repository_exception_reraised` now verifies the message is preserved (`match="not found"`)
- [x] `test_failed_hook_reraised_as_repository_exception` now verifies the message is preserved (`match="hook fail"`)
- [x] Lint passes
- [ ] CI passes on this branch