### PR TITLE
Code health: fix mislocated utilities, exception safety, and stale TODOs

### DIFF
--- a/cookieplone/cli/__init__.py
+++ b/cookieplone/cli/__init__.py
@@ -100,10 +100,6 @@ def annotate_context(context: dict, repo_path: Path, template: str) -> dict:
     return context
 
 
-def parse_boolean(value: str) -> bool:
-    return value.lower() in ("1", "yes", "y")
-
-
 def prompt_for_template(base_path: Path, all_: bool = False) -> t.CookieploneTemplate:
     """Parse cookiecutter.json in base_path and prompt user to choose."""
     templates = get_template_options(base_path, all_)
@@ -281,14 +277,12 @@ def cli(
         generate(gen_config)
     except GeneratorException as exc:
         console.error(exc.message)
-        # TODO: Handle error
         raise typer.Exit(1)  # noQA:B904
     except PreFlightException as exc:
         console.error(exc.message)
         raise typer.Exit(1)  # noQA:B904
     except Exception as exc:
         console.error(str(exc))
-        # TODO: Handle error
         raise typer.Exit(1)  # noQA:B904
 
 

--- a/cookieplone/filters/__init__.py
+++ b/cookieplone/filters/__init__.py
@@ -5,8 +5,8 @@ import os
 
 from cookiecutter.utils import simple_filter
 
-from cookieplone.cli import parse_boolean
 from cookieplone.utils import containers, npm, versions
+from cookieplone.utils.parsers import parse_boolean
 
 
 @simple_filter

--- a/cookieplone/generator/__init__.py
+++ b/cookieplone/generator/__init__.py
@@ -17,7 +17,8 @@ from cookieplone.exceptions import (
 from cookieplone.generator.main import cookieplone
 from cookieplone.repository import get_repository
 from cookieplone.settings import COOKIEPLONE_ANSWERS_FILE
-from cookieplone.utils import answers, console, cookiecutter, files
+from cookieplone.utils import answers, cookiecutter, files
+from cookieplone.utils.console import quiet_mode
 from cookieplone.utils.cookiecutter import load_replay
 
 
@@ -160,8 +161,6 @@ def generate_subtemplate(
     extra_context = answers.remove_internal_keys(context)
     ## Add folder name again
     extra_context["__folder_name"] = folder_name
-    # Enable quiet mode
-    console.enable_quiet_mode()
     # Files to be removed
     if remove_files is None:
         remove_files = []
@@ -176,15 +175,9 @@ def generate_subtemplate(
         template_path=template_path,
         dump_answers=False,
     )
-    try:
+    with quiet_mode():
         result = generate(config)
-    except GeneratorException as exc:
-        console.disable_quiet_mode()
-        raise exc
-    else:
-        console.disable_quiet_mode()
-        path = Path(result)
-        if remove_files:
-            files.remove_files(path, remove_files)
-        # Return path
-        return path
+    path = Path(result)
+    if remove_files:
+        files.remove_files(path, remove_files)
+    return path

--- a/cookieplone/utils/config.py
+++ b/cookieplone/utils/config.py
@@ -135,9 +135,10 @@ def convert_v1_to_v2(src: dict[str, Any]) -> dict[str, Any]:
             prop["type"] = "integer"
         elif isinstance(raw_value, str):
             prop["type"] = "string"
-        # TODO: Handle sub-dicts
-        # elif isinstance(raw_value, dict):
-        #     prop["type"] = "string"
+        # Sub-dict values (nested dicts) are not yet supported in the
+        # cookieplone schema; they would need a recursive conversion or a
+        # dedicated "object" type.  For now they fall through to the
+        # ValueError below.
         else:
             raise ValueError(f"Unsupported type for key '{key}': {type(raw_value)}")
         properties[key] = prop

--- a/cookieplone/utils/console.py
+++ b/cookieplone/utils/console.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 import os
+from contextlib import contextmanager
 from pathlib import Path
 from textwrap import dedent
 
@@ -218,3 +219,16 @@ def enable_quiet_mode():
 def disable_quiet_mode():
     """Disable quiet mode."""
     os.environ.pop(QUIET_MODE_VAR, "")
+
+
+@contextmanager
+def quiet_mode():
+    """Context manager that enables quiet mode for the duration of the block.
+
+    Quiet mode is always disabled on exit, even if an exception is raised.
+    """
+    enable_quiet_mode()
+    try:
+        yield
+    finally:
+        disable_quiet_mode()

--- a/cookieplone/utils/cookiecutter.py
+++ b/cookieplone/utils/cookiecutter.py
@@ -24,8 +24,10 @@ def import_patch(repo_dir: Path | str):
     """
     current_path = copy(sys.path)
     sys.path.append(str(repo_dir))
-    yield
-    sys.path = current_path
+    try:
+        yield
+    finally:
+        sys.path = current_path
 
 
 def load_replay(

--- a/cookieplone/utils/parsers.py
+++ b/cookieplone/utils/parsers.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2024-present Plone Foundation <board@plone.org>
+#
+# SPDX-License-Identifier: MIT
+
+
+def parse_boolean(value: str) -> bool:
+    """Parse a string value into a boolean.
+
+    Recognises ``"1"``, ``"yes"`` and ``"y"`` (case-insensitive) as truthy.
+    All other values are considered falsy.
+
+    :param value: The string to parse.
+    :returns: ``True`` if the value is truthy, ``False`` otherwise.
+    """
+    return value.lower() in ("1", "yes", "y")

--- a/news/148.internal
+++ b/news/148.internal
@@ -1,0 +1,1 @@
+Code health: moved ``parse_boolean`` to ``utils.parsers``, fixed ``import_patch`` exception safety, added ``quiet_mode()`` context manager, and resolved stale TODO comments. @ericof

--- a/tests/generator/conftest.py
+++ b/tests/generator/conftest.py
@@ -95,11 +95,22 @@ def mock_generate(monkeypatch):
 
 
 @pytest.fixture()
-def mock_console(monkeypatch):
-    """Patch cookieplone.generator.console."""
-    mock = MagicMock()
-    monkeypatch.setattr("cookieplone.generator.console", mock)
-    return mock
+def mock_quiet_mode(monkeypatch):
+    """Patch cookieplone.generator.quiet_mode with a no-op context manager."""
+    from contextlib import contextmanager
+
+    calls = {"enter": 0, "exit": 0}
+
+    @contextmanager
+    def _fake_quiet_mode():
+        calls["enter"] += 1
+        try:
+            yield
+        finally:
+            calls["exit"] += 1
+
+    monkeypatch.setattr("cookieplone.generator.quiet_mode", _fake_quiet_mode)
+    return calls
 
 
 @pytest.fixture()

--- a/tests/generator/test_generate_subtemplate.py
+++ b/tests/generator/test_generate_subtemplate.py
@@ -9,14 +9,14 @@ from cookieplone.exceptions import GeneratorException
 from cookieplone.generator import generate_subtemplate
 
 
-def test_enables_quiet_mode(
+def test_uses_quiet_mode(
     mock_remove_internal_keys,
     mock_get_repository_root,
-    mock_console,
+    mock_quiet_mode,
     mock_generate,
     tmp_path,
 ):
-    """generate_subtemplate enables quiet mode."""
+    """generate_subtemplate runs inside a quiet_mode context manager."""
     mock_remove_internal_keys.return_value = {"title": "Test"}
     mock_get_repository_root.return_value = str(tmp_path / "repo")
     mock_generate.return_value = tmp_path / "output"
@@ -28,39 +28,18 @@ def test_enables_quiet_mode(
         folder_name="my_folder",
         context=context,
     )
-    mock_console.enable_quiet_mode.assert_called_once()
+    assert mock_quiet_mode["enter"] == 1
+    assert mock_quiet_mode["exit"] == 1
 
 
-def test_disables_quiet_mode_on_success(
+def test_quiet_mode_exits_on_failure(
     mock_remove_internal_keys,
     mock_get_repository_root,
-    mock_console,
+    mock_quiet_mode,
     mock_generate,
     tmp_path,
 ):
-    """generate_subtemplate disables quiet mode after success."""
-    mock_remove_internal_keys.return_value = {"title": "Test"}
-    mock_get_repository_root.return_value = str(tmp_path / "repo")
-    mock_generate.return_value = tmp_path / "output"
-    context = OrderedDict({"title": "Test", "_template": "/some/path"})
-
-    generate_subtemplate(
-        template_path="sub",
-        output_dir=tmp_path,
-        folder_name="my_folder",
-        context=context,
-    )
-    mock_console.disable_quiet_mode.assert_called_once()
-
-
-def test_disables_quiet_mode_on_failure(
-    mock_remove_internal_keys,
-    mock_get_repository_root,
-    mock_console,
-    mock_generate,
-    tmp_path,
-):
-    """generate_subtemplate disables quiet mode even on failure."""
+    """generate_subtemplate exits quiet mode even on failure."""
     mock_remove_internal_keys.return_value = {"title": "Test"}
     mock_get_repository_root.return_value = str(tmp_path / "repo")
     state = CookieploneState(
@@ -78,13 +57,14 @@ def test_disables_quiet_mode_on_failure(
             folder_name="my_folder",
             context=context,
         )
-    mock_console.disable_quiet_mode.assert_called_once()
+    assert mock_quiet_mode["enter"] == 1
+    assert mock_quiet_mode["exit"] == 1
 
 
 def test_calls_generate_with_no_input(
     mock_remove_internal_keys,
     mock_get_repository_root,
-    mock_console,
+    mock_quiet_mode,
     mock_generate,
     tmp_path,
 ):
@@ -107,7 +87,7 @@ def test_calls_generate_with_no_input(
 def test_sets_folder_name_in_extra_context(
     mock_remove_internal_keys,
     mock_get_repository_root,
-    mock_console,
+    mock_quiet_mode,
     mock_generate,
     tmp_path,
 ):
@@ -130,7 +110,7 @@ def test_sets_folder_name_in_extra_context(
 def test_removes_files_when_specified(
     mock_remove_internal_keys,
     mock_get_repository_root,
-    mock_console,
+    mock_quiet_mode,
     mock_generate,
     mock_remove_files,
     tmp_path,
@@ -156,7 +136,7 @@ def test_removes_files_when_specified(
 def test_returns_path(
     mock_remove_internal_keys,
     mock_get_repository_root,
-    mock_console,
+    mock_quiet_mode,
     mock_generate,
     tmp_path,
 ):


### PR DESCRIPTION
## Summary

Addresses code health items from #148: mislocated utilities, exception safety gaps, global state patterns, and stale TODOs.

- **Moved `parse_boolean`** out of `cli/__init__.py` into `utils/parsers.py` — it's a general-purpose utility, not CLI-specific
- **Fixed `import_patch` exception safety** — `sys.path` restoration now uses `try/finally` so it's restored even if the `yield` block raises
- **Added `quiet_mode()` context manager** to `utils/console.py` and refactored `generate_subtemplate` to use it — quiet mode is now exception-safe without manual enable/disable calls
- **Resolved 3 stale TODO comments** — removed two dead `# TODO: Handle error` in the CLI (handling was already in place), converted the `utils/config.py` TODO into an explanatory comment about unsupported sub-dict types
- **`_annotate_data` mutation contract** was already documented in #152 (docstring + test), no further changes needed

Closes #148

## Test plan

- [x] All 615 tests pass
- [x] Lint passes (ruff, codespell, pyroma, pre-commit)
- [x] `test_generate_subtemplate` tests updated to verify `quiet_mode()` context manager enter/exit
- [x] No documentation changes needed (all changed items are internal utilities)
- [ ] CI passes on this branch