### PR TITLE
Load global_versions in Cookies.bake() helper

### DIFF
--- a/cookieplone/templates/bake.py
+++ b/cookieplone/templates/bake.py
@@ -4,7 +4,30 @@ from pathlib import Path
 from cookieplone._types import RunConfig
 from cookieplone.config import CookieploneState, generate_state
 from cookieplone.generator.main import cookieplone
-from cookieplone.repository import get_repository
+from cookieplone.repository import (
+    REPO_CONFIG_FILENAME,
+    get_repository,
+    get_repository_config,
+)
+
+
+def _discover_global_versions(template_path: Path) -> dict[str, str]:
+    """Walk upward from *template_path* looking for ``cookieplone-config.json``.
+
+    When found, return its ``config.versions`` mapping so templates tested via
+    :class:`Cookies` can resolve ``{{ versions.<key> }}`` the same way the CLI
+    does.  Returns an empty dict when no repository config is present or when
+    it fails validation.
+    """
+    candidate = template_path.resolve()
+    for parent in (candidate, *candidate.parents):
+        if (parent / REPO_CONFIG_FILENAME).is_file():
+            try:
+                repo_config = get_repository_config(parent)
+            except RuntimeError:
+                return {}
+            return repo_config.get("config", {}).get("versions", {})
+    return {}
 
 
 @dataclass
@@ -70,8 +93,11 @@ class Cookies:
             str(self._config_file),
             False,
         )
+        global_versions = _discover_global_versions(template_path)
         state: CookieploneState = generate_state(
-            template_path=template_path, extra_context=extra_context
+            template_path=template_path,
+            extra_context=extra_context,
+            global_versions=global_versions,
         )
         run_config = RunConfig(
             output_dir=self._new_output_dir(),

--- a/news/164.bugfix
+++ b/news/164.bugfix
@@ -1,0 +1,1 @@
+Fixed `Cookies.bake()` helper to load `global_versions` from `cookieplone-config.json` so templates tested via pytest can resolve `{{ versions.<key> }}` the same way the CLI does. @ericof

--- a/tests/templates/test_bake.py
+++ b/tests/templates/test_bake.py
@@ -1,0 +1,27 @@
+"""Regression tests for :mod:`cookieplone.templates.bake`."""
+
+from pathlib import Path
+
+from cookieplone.templates.bake import _discover_global_versions
+
+
+class TestDiscoverGlobalVersions:
+    def test_returns_versions_when_repo_config_present(self, resources_folder: Path):
+        """Walk upward from a template path and pick up ``config.versions``."""
+        repo_root = (resources_folder / "templates_repo_config").resolve()
+        template_path = repo_root / "templates" / "projects" / "monorepo"
+        result = _discover_global_versions(template_path)
+        assert result == {"gha_version_checkout": "v6"}
+
+    def test_returns_empty_when_no_repo_config(self, tmp_path: Path):
+        """Return an empty dict when no ``cookieplone-config.json`` is found."""
+        template_path = tmp_path / "standalone" / "template"
+        template_path.mkdir(parents=True)
+        assert _discover_global_versions(template_path) == {}
+
+    def test_returns_empty_when_config_is_invalid(self, tmp_path: Path):
+        """Return an empty dict when the repo config fails validation."""
+        (tmp_path / "cookieplone-config.json").write_text("{}")
+        template_path = tmp_path / "templates" / "project"
+        template_path.mkdir(parents=True)
+        assert _discover_global_versions(template_path) == {}


### PR DESCRIPTION
## Summary

- Teach `Cookies.bake()` to walk upward from the template path, load `cookieplone-config.json` when present, and forward its `config.versions` to `generate_state()` as `global_versions`.
- Mirrors the CLI path in `repository.get_repository()` so templates tested via pytest can resolve `{{ versions.<key> }}` the same way an interactive `cookieplone` run would.
- Add a `news/164.bugfix` fragment and targeted unit tests in `tests/templates/test_bake.py` covering the happy path, missing config, and invalid config cases.

Closes #164

## Motivation

`plone/cookieplone-templates` is migrating its monorepo project template to the v2 schema (plone/cookieplone-templates#359). Template files now reference repository-level versions via `{{ versions.devops_traefik_version }}`, `{{ versions.backend_python }}`, etc. These render correctly via the CLI but every test in the templates repo failed with `Variable 'devops_traefik_version' is undefined`, because the pytest helper never loaded the repo-level config. This PR makes the helper behaviorally equivalent to the CLI.

## Test plan

- [x] `uv run pytest tests/templates/test_bake.py -v` — 3 new tests pass
- [x] `uv run pytest tests` — full cookieplone suite (793 tests) stays green
- [x] In `plone/cookieplone-templates` on `issue-359`, with this branch installed via `uv add --editable`, `make test` goes from 274 failures to all 1194 tests passing