### PR TITLE
Add run_subtemplates() helper and deprecate generate_subtemplate

### DIFF
--- a/cookieplone/generator/__init__.py
+++ b/cookieplone/generator/__init__.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+import os
+import warnings
 from collections import OrderedDict
 from pathlib import Path
 
@@ -16,7 +18,7 @@ from cookieplone.exceptions import (
 )
 from cookieplone.generator.main import cookieplone
 from cookieplone.repository import get_repository
-from cookieplone.settings import COOKIEPLONE_ANSWERS_FILE
+from cookieplone.settings import COOKIEPLONE_ANSWERS_FILE, QUIET_MODE_VAR
 from cookieplone.utils import answers, cookiecutter, files
 from cookieplone.utils.console import quiet_mode
 from cookieplone.utils.cookiecutter import load_replay
@@ -144,6 +146,11 @@ def generate_subtemplate(
     nested template.  Quiet mode is enabled for the duration so that the
     sub-template's output does not clutter the parent run's UI.
 
+    .. deprecated:: 2.0.0
+        Use :func:`~cookieplone.utils.subtemplates.run_subtemplates` instead,
+        which handles the full subtemplates loop with automatic fallback for
+        subtemplates that don't need custom handlers.
+
     :param template_path: Relative path (within the repository) to the
         sub-template directory.
     :param output_dir: Directory where the sub-template output should be
@@ -156,6 +163,16 @@ def generate_subtemplate(
     :returns: Path to the generated sub-template directory.
     :raises GeneratorException: If generation of the sub-template fails.
     """
+    # Suppress the deprecation warning while quiet mode is active, so that
+    # subtemplate runs driven by run_subtemplates() do not flood the parent
+    # run's UI with repeated warnings for each dispatched subtemplate.
+    if not os.environ.get(QUIET_MODE_VAR):
+        warnings.warn(
+            "generate_subtemplate() is deprecated. "
+            "Use cookieplone.utils.subtemplates.run_subtemplates() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     # Extract path to repository
     repository = files.get_repository_root(context, template_path)
     # Cleanup context

--- a/cookieplone/settings.py
+++ b/cookieplone/settings.py
@@ -72,6 +72,9 @@ TEMPLATES_REPO = "https://github.com/plone/cookieplone-templates"
 REPO_DEFAULT = "gh:plone/cookieplone-templates"
 REPO_DEFAULT_TAG = "next"  # Default branch of cookieplone-templates
 
+# Subtemplates
+TEMPLATES_FOLDER = "templates"
+
 # Config
 QUIET_MODE_VAR = "COOKIEPLONE_QUIET_MODE_SWITCH"
 REPO_LOCATION = "COOKIEPLONE_REPOSITORY"

--- a/cookieplone/utils/subtemplates.py
+++ b/cookieplone/utils/subtemplates.py
@@ -1,7 +1,23 @@
+"""Helpers for post-generation hooks that orchestrate sub-template rendering."""
+
+import logging
+from collections import OrderedDict
+from collections.abc import Callable
+from copy import deepcopy
+from pathlib import Path
 from typing import Any
 
 from cookieplone.config import CookieploneState
+from cookieplone.settings import TEMPLATES_FOLDER
+from cookieplone.utils.console import print as console_print
+from cookieplone.utils.console import quiet_mode
 from cookieplone.utils.cookiecutter import create_jinja_env
+
+logger = logging.getLogger(__name__)
+
+#: Signature for custom subtemplate handler functions.
+#: Receives ``(context, output_dir)`` and returns the generated directory path.
+SubtemplateHandler = Callable[[OrderedDict, Path], Path]
 
 
 def process_subtemplates(
@@ -24,3 +40,118 @@ def process_subtemplates(
         [s["id"], s["title"], env.from_string(s["enabled"]).render()]
         for s in subtemplates
     ]
+
+
+def _parse_subtemplate_entry(
+    entry: list | dict,
+) -> dict[str, str]:
+    """Normalise a single subtemplate entry into a dict.
+
+    Supports both legacy tuple/list format ``[id, title, enabled]`` and the
+    new dict format ``{"id": ..., "title": ..., "enabled": ..., "folder_name": ...}``.
+
+    :param entry: A subtemplate entry in either format.
+    :returns: A dict with keys ``id``, ``title``, ``enabled``, and ``folder_name``.
+    :raises ValueError: If the entry format is not recognized.
+    """
+    if isinstance(entry, dict):
+        result = {
+            "id": entry["id"],
+            "title": entry["title"],
+            "enabled": entry["enabled"],
+            "folder_name": entry.get("folder_name", ""),
+        }
+    elif isinstance(entry, (list, tuple)) and len(entry) >= 3:
+        result = {
+            "id": entry[0],
+            "title": entry[1],
+            "enabled": entry[2],
+            "folder_name": entry[3] if len(entry) > 3 else "",
+        }
+    else:
+        raise ValueError(f"Unrecognized subtemplate entry format: {entry!r}")
+    return result
+
+
+def run_subtemplates(
+    context: OrderedDict,
+    output_dir: Path,
+    handlers: dict[str, SubtemplateHandler] | None = None,
+) -> dict[str, Path]:
+    """Process and generate all subtemplates defined in the context.
+
+    This is the main entry point for post-generation hooks to trigger
+    subtemplate generation. It replaces the boilerplate loop that was
+    previously duplicated across every ``post_gen_project.py``.
+
+    For each enabled subtemplate:
+
+    - If a matching handler is provided, it is called with a deep copy
+      of the context and the output directory.
+    - Otherwise, :func:`~cookieplone.generator.generate_subtemplate` is
+      called with default arguments.
+
+    Disabled subtemplates are logged and skipped.
+
+    :param context: The cookiecutter context ``OrderedDict`` from the
+        post-generation hook.
+    :param output_dir: The generated project directory (typically
+        ``Path.cwd()``).
+    :param handlers: Optional mapping of ``template_id`` →
+        :data:`SubtemplateHandler` for subtemplates that need custom
+        context manipulation.
+    :returns: Dict mapping ``template_id`` → generated ``Path`` for
+        each subtemplate that was processed.
+    """
+    from cookieplone.generator import generate_subtemplate
+
+    if handlers is None:
+        handlers = {}
+
+    raw_subtemplates = context.get("__cookieplone_subtemplates", [])
+    results: dict[str, Path] = {}
+
+    for entry in raw_subtemplates:
+        sub = _parse_subtemplate_entry(entry)
+        template_id = sub["id"]
+        title = sub["title"]
+        enabled = sub["enabled"]
+        folder_name = sub["folder_name"]
+
+        if not int(enabled):
+            console_print(f" -> Ignoring ({title})")
+            continue
+
+        console_print(f" -> {title}")
+
+        # Enter quiet mode for the duration of the dispatch so that nested
+        # generate_subtemplate() calls — both from registered handlers and
+        # from the default fallback — do not emit their own console output
+        # or deprecation warnings while the parent run is active.
+        with quiet_mode():
+            if template_id in handlers:
+                path = handlers[template_id](deepcopy(context), output_dir)
+            else:
+                # Default generation: resolve folder_name from entry or
+                # project dir.
+                if folder_name == ".":
+                    gen_output_dir = output_dir.parent
+                    gen_folder_name = output_dir.name
+                elif folder_name:
+                    gen_output_dir = output_dir
+                    gen_folder_name = folder_name
+                else:
+                    gen_output_dir = output_dir
+                    gen_folder_name = output_dir.name
+
+                template_path = f"{TEMPLATES_FOLDER}/{template_id}"
+                path = generate_subtemplate(
+                    template_path=template_path,
+                    output_dir=gen_output_dir,
+                    folder_name=gen_folder_name,
+                    context=deepcopy(context),
+                )
+
+        results[template_id] = path
+
+    return results

--- a/docs/src/concepts/subtemplates.md
+++ b/docs/src/concepts/subtemplates.md
@@ -86,35 +86,63 @@ During generation, these entries are converted into `[id, title, enabled]` lists
 
 See {doc}`/reference/schema-v2` for the full specification of the `config.subtemplates` format.
 
-## Calling a sub-template from a hook
+## Calling sub-templates from a hook
 
-A post-generation hook in the `project` template calls the sub-templates after the main template is rendered:
+A post-generation hook in the main template triggers the sub-templates after the top-level project is rendered.
+Cookieplone ships a helper, {py:func}`cookieplone.utils.subtemplates.run_subtemplates`, that reads the `__cookieplone_subtemplates` entries from the context and dispatches each one:
 
 ```python
 # hooks/post_gen_project.py
-import subprocess
-import sys
+from collections import OrderedDict
+from pathlib import Path
+
+from cookieplone.utils.subtemplates import run_subtemplates
+
+context: OrderedDict = {{cookiecutter}}
 
 
-def run_sub_template(template_name: str) -> None:
-    result = subprocess.run(
-        [
-            sys.executable, "-m", "cookieplone",
-            template_name,
-            "--no-input",
-            "--answers", ".cookieplone.json",
-            "--output-dir", "..",
-        ],
-        check=False,
-    )
-    if result.returncode != 0:
-        sys.exit(result.returncode)
+def main():
+    output_dir = Path.cwd()
+    # {{ cookiecutter.__cookieplone_subtemplates }}
+    run_subtemplates(context, output_dir)
 
 
 if __name__ == "__main__":
-    run_sub_template("backend")
-    run_sub_template("frontend")
+    main()
 ```
+
+For each enabled entry, `run_subtemplates()`:
+
+1. Skips it (with a log line) when `enabled` evaluates to `0`.
+2. Calls a **custom handler** if you registered one for that sub-template `id`.
+3. Otherwise falls back to a default call to {py:func}`cookieplone.generator.generate_subtemplate` using the entry's `folder_name`.
+
+### Custom handlers
+
+Most real projects need per-sub-template tweaks: injecting extra context keys, rewriting the output folder, or post-processing generated files.
+Pass a `handlers` dict mapping `template_id` → callable with signature `(context, output_dir) -> Path`:
+
+```python
+from cookieplone.utils.subtemplates import run_subtemplates
+
+
+def generate_backend(context, output_dir):
+    context["feature_headless"] = "1"
+    return generator.generate_subtemplate(
+        "templates/add-ons/backend", output_dir, "backend", context,
+    )
+
+
+SUBTEMPLATE_HANDLERS = {
+    "add-ons/backend": generate_backend,
+}
+
+run_subtemplates(context, output_dir, handlers=SUBTEMPLATE_HANDLERS)
+```
+
+Handlers receive a deep copy of the context, so in-place mutations are safe and do not leak across sub-templates.
+
+For a full real-world example that registers seven handlers covering backend, frontend, docs, CI, IDE, and shared sub-templates, see {doc}`/how-to-guides/call-subtemplates-from-a-hook`.
 
 ## Hidden sub-templates
 
@@ -141,5 +169,6 @@ A repository can expose several equally prominent templates—for example, a `pr
 ## Related pages
 
 - {doc}`/concepts/template-repositories`: how the root `cookiecutter.json` is structured.
+- {doc}`/how-to-guides/call-subtemplates-from-a-hook`: walk through a real post-generation hook using `run_subtemplates()`.
 - {doc}`/how-to-guides/create-a-hidden-template`: mark a template as hidden.
 - {doc}`/reference/schema-v2`: the per-template schema format.

--- a/docs/src/how-to-guides/call-subtemplates-from-a-hook.md
+++ b/docs/src/how-to-guides/call-subtemplates-from-a-hook.md
@@ -1,0 +1,232 @@
+---
+myst:
+  html_meta:
+    "description": "How to orchestrate sub-template generation from a post-generation hook using run_subtemplates and custom handlers."
+    "property=og:description": "How to orchestrate sub-template generation from a post-generation hook using run_subtemplates and custom handlers."
+    "property=og:title": "Call sub-templates from a hook"
+    "keywords": "Cookieplone, sub-templates, post_gen_project, run_subtemplates, handlers, monorepo"
+---
+
+# Call sub-templates from a hook
+
+This guide shows how to drive sub-template generation from a top-level template's `post_gen_project.py`, using {py:func}`cookieplone.utils.subtemplates.run_subtemplates` and a dictionary of custom handlers.
+It uses the `monorepo` project template from [`plone/cookieplone-templates`](https://github.com/plone/cookieplone-templates) as a reference: that template composes a full Plone project out of seven sub-templates (backend, frontend, docs, cache, project settings, CI, and VS Code configuration).
+
+## Prerequisites
+
+- You already have a template repository that declares sub-templates (see {doc}`/concepts/subtemplates`).
+- Your main template's `cookieplone.json` lists the sub-templates to run under `config.subtemplates`.
+- You know which sub-templates need custom handling (extra context, folder rewrites, post-processing) and which can fall through to the default generator.
+
+## Step 1: Import the helper
+
+At the top of `hooks/post_gen_project.py`:
+
+```python
+from collections import OrderedDict
+from pathlib import Path
+
+from cookieplone import generator
+from cookieplone.utils import console, files, git, npm, plone
+from cookieplone.utils.subtemplates import run_subtemplates
+
+context: OrderedDict = {{cookiecutter}}
+versions: dict | OrderedDict = {{versions}}
+```
+
+The `{{cookiecutter}}` and `{{versions}}` markers are Jinja substitutions that Cookiecutter fills in with the rendered context and the loaded `global_versions` mapping.
+
+## Step 2: Write one handler per sub-template
+
+A handler must have the signature `(context: OrderedDict, output_dir: Path) -> Path` and return the directory that the sub-template generated into.
+`run_subtemplates()` passes a deep copy of the context to each handler, so mutating `context` in place is safe.
+
+### A simple handler
+
+The backend sub-template needs a headless flavor and should skip CI/docs scaffolding (those belong to the parent project), then clean up residual `.git` artifacts:
+
+```python
+BACKEND_ADDON_REMOVE = [".git"]
+TEMPLATES_FOLDER = "templates"
+
+
+def generate_addons_backend(context: OrderedDict, output_dir: Path) -> Path:
+    """Run the Plone backend add-on generator."""
+    folder_name = "backend"
+    context["feature_headless"] = "1"
+    context["initialize_ci"] = "0"
+    context["initialize_documentation"] = "0"
+    path = generator.generate_subtemplate(
+        f"{TEMPLATES_FOLDER}/add-ons/backend",
+        output_dir,
+        folder_name,
+        context,
+        BACKEND_ADDON_REMOVE,
+    )
+    files.remove_files(output_dir / folder_name, BACKEND_ADDON_REMOVE)
+    return path
+```
+
+Key points:
+
+- The handler **mutates context** freely; the copy is local.
+- It returns the `Path` produced by {py:func}`cookieplone.generator.generate_subtemplate`.
+- Extra cleanup (`files.remove_files`) happens after generation but still inside the handler.
+
+### A handler with post-processing
+
+The frontend handler does more work: it normalizes scoped npm package names, disables release automation in `.release-it.json`, and rewrites hard-coded repository URLs in the generated files.
+
+```python
+def generate_addons_frontend(context: OrderedDict, output_dir: Path) -> Path:
+    """Run the Volto add-on generator."""
+    folder_name = "frontend"
+    context = _fix_frontend_addon_name(context)
+    frontend_addon_name = context["frontend_addon_name"]
+    context["initialize_documentation"] = "0"
+    context["initialize_ci"] = "0"
+    path = generator.generate_subtemplate(
+        f"{TEMPLATES_FOLDER}/add-ons/frontend",
+        output_dir,
+        folder_name,
+        context,
+        FRONTEND_ADDON_REMOVE,
+    )
+    # Disable release automation that only makes sense for stand-alone add-ons.
+    release_it_path = path / "packages" / frontend_addon_name / ".release-it.json"
+    if release_it_path.is_file():
+        data = json.loads(release_it_path.read_text())
+        data["github"]["release"] = False
+        data["plonePrePublish"]["publish"] = False
+        data["npm"]["publish"] = False
+        release_it_path.write_text(json.dumps(data, indent=2))
+    # Rewrite stand-alone repository URLs to point at the parent monorepo.
+    _find_replace_in_folder(path, {
+        "https://github.com/.../frontend_addon_name":
+            "{{ cookiecutter.__repository_url }}",
+    })
+    return path
+```
+
+### A handler with a composed context
+
+Some sub-templates run against a narrower context built from the parent's answers. For example, the GitHub Actions CI sub-template only needs a handful of derived values:
+
+```python
+def generate_ci_gh_project(context: OrderedDict, output_dir: Path) -> Path:
+    """Generate GitHub Actions workflows for the monorepo."""
+    ci_context = OrderedDict({
+        "npm_package_name": context["__npm_package_name"],
+        "container_image_prefix": context["__container_image_prefix"],
+        "python_version": versions["backend_python"],
+        "node_version": context["__node_version"],
+        "has_cache": context["devops_cache"],
+        "has_docs": context["initialize_documentation"],
+        "has_deploy": context["devops_gha_deploy"],
+        "__cookieplone_repository_path": context["__cookieplone_repository_path"],
+    })
+    return generator.generate_subtemplate(
+        f"{TEMPLATES_FOLDER}/ci/gh_project",
+        output_dir,
+        ".github",
+        ci_context,
+    )
+```
+
+The generated files land in `.github/` at the project root, which is why the handler passes `folder_name=".github"` explicitly.
+
+### A handler that rewrites the output directory
+
+Some sub-templates need to be rendered **as** the parent directory. For example, a cache sub-template that adds files next to the project without introducing a new folder:
+
+```python
+def generate_sub_cache(context: OrderedDict, output_dir: Path) -> Path:
+    """Add cache structure to the existing project folder."""
+    folder_name = output_dir.name
+    parent_dir = output_dir.parent
+    return generator.generate_subtemplate(
+        f"{TEMPLATES_FOLDER}/sub/cache", parent_dir, folder_name, context,
+    )
+```
+
+## Step 3: Register the handlers
+
+Collect every handler in a module-level dict keyed by the sub-template `id` (the same `id` declared in `config.subtemplates` in your `cookieplone.json`):
+
+```python
+SUBTEMPLATE_HANDLERS = {
+    "add-ons/backend": generate_addons_backend,
+    "add-ons/frontend": generate_addons_frontend,
+    "docs/starter": generate_docs_starter,
+    "sub/cache": generate_sub_cache,
+    "sub/project_settings": generate_sub_project_settings,
+    "ci/gh_project": generate_ci_gh_project,
+    "ide/vscode": generate_ide_vscode,
+}
+```
+
+If a sub-template is declared in `config.subtemplates` but **not** present in this dict, `run_subtemplates()` will fall back to a default call with the entry's `folder_name`.
+That fallback is useful for straightforward sub-templates that only need the defaults.
+
+## Step 4: Invoke `run_subtemplates()` from `main()`
+
+Inside the `main()` function of your post-generation hook, replace any manual loop over `__cookieplone_subtemplates` with a single call:
+
+```python
+def main():
+    output_dir = Path.cwd()
+
+    # {{ cookiecutter.__cookieplone_subtemplates }}
+    run_subtemplates(context, output_dir, handlers=SUBTEMPLATE_HANDLERS)
+
+    # Continue with other post-generation tasks (namespace packages,
+    # code formatting, git initialization, ...).
+    plone.create_namespace_packages(
+        output_dir / "backend/src/packagename",
+        context.get("python_package_name"),
+        style="native",
+    )
+
+
+if __name__ == "__main__":
+    main()
+```
+
+The trailing `# {{ cookiecutter.__cookieplone_subtemplates }}` comment is **important**: it ensures Cookiecutter treats the sub-templates list as a rendered context value, which is what `run_subtemplates()` then reads at runtime.
+
+## Why use `run_subtemplates()`
+
+Before the helper existed, every monorepo hook implemented its own loop:
+
+```python
+# Old pattern, do not copy into new templates.
+funcs = {k: v for k, v in globals().items() if k.startswith("generate_")}
+for template_id, title, enabled in subtemplates:
+    template_slug = template_id.replace("/", "_").replace("-", "")
+    func_name = f"generate_{template_slug}"
+    func = funcs.get(func_name)
+    if not func:
+        raise ValueError(f"No handler for {template_id}")
+    ...
+```
+
+Using `run_subtemplates()` gives you:
+
+- **Explicit dispatch.** Handlers are wired up in a visible dict rather than discovered by name munging.
+- **Consistent logging and deep-copying.** The helper prints each step and guarantees that handlers can not accidentally mutate a shared context.
+- **Default fallback.** Simple sub-templates no longer require a matching handler at all.
+- **Schema compatibility.** Both the legacy `[id, title, enabled]` format and the dict format with `folder_name` are accepted transparently.
+
+## Full example
+
+The complete reference implementation is the monorepo template in the `cookieplone-templates` repository:
+
+> [`templates/projects/monorepo/hooks/post_gen_project.py`](https://github.com/plone/cookieplone-templates/blob/next/templates/projects/monorepo/hooks/post_gen_project.py)
+
+Read it alongside this guide when you build your own multi-part template.
+
+## Related pages
+
+- {doc}`/concepts/subtemplates`: background on how sub-templates are declared and composed.
+- {doc}`/reference/schema-v2`: the per-template schema, including `config.subtemplates`.
+- {doc}`/how-to-guides/create-a-hidden-template`: hide sub-templates from the main menu.

--- a/docs/src/how-to-guides/index.md
+++ b/docs/src/how-to-guides/index.md
@@ -35,6 +35,7 @@ add-validators-to-your-template
 add-computed-fields
 use-built-in-filters
 create-a-hidden-template
+call-subtemplates-from-a-hook
 write-a-pre-prompt-hook
 ```
 

--- a/docs/styles/config/vocabularies/Plone/accept.txt
+++ b/docs/styles/config/vocabularies/Plone/accept.txt
@@ -28,6 +28,7 @@ JavaScript
 jQuery
 libxslt
 Mockup
+monorepo
 npm
 nvm
 Pastanaga

--- a/news/119.documentation
+++ b/news/119.documentation
@@ -1,0 +1,1 @@
+Documented how to drive sub-template generation from a post-generation hook with `run_subtemplates()` and a dictionary of custom handlers, using the `monorepo` project template as a reference. @ericof

--- a/news/119.feature
+++ b/news/119.feature
@@ -1,0 +1,1 @@
+Added `cookieplone.utils.subtemplates.run_subtemplates()`, a helper that post-generation hooks can use to drive sub-template generation via an explicit `{template_id: handler}` dispatch dict, with a default fallback for sub-templates that do not need custom handling. The legacy `cookieplone.generator.generate_subtemplate()` entry point is now deprecated. @ericof

--- a/tests/generator/test_generate_subtemplate.py
+++ b/tests/generator/test_generate_subtemplate.py
@@ -1,5 +1,6 @@
 """Tests for generate_subtemplate."""
 
+import warnings
 from collections import OrderedDict
 
 import pytest
@@ -7,6 +8,7 @@ import pytest
 from cookieplone.config.state import CookieploneState
 from cookieplone.exceptions import GeneratorException
 from cookieplone.generator import generate_subtemplate
+from cookieplone.settings import QUIET_MODE_VAR
 
 
 def test_uses_quiet_mode(
@@ -154,3 +156,56 @@ def test_returns_path(
         context=context,
     )
     assert result == expected
+
+
+def test_warns_when_not_in_quiet_mode(
+    mock_remove_internal_keys,
+    mock_get_repository_root,
+    mock_quiet_mode,
+    mock_generate,
+    tmp_path,
+    monkeypatch,
+):
+    """generate_subtemplate emits a DeprecationWarning by default."""
+    monkeypatch.delenv(QUIET_MODE_VAR, raising=False)
+    mock_remove_internal_keys.return_value = {"title": "Test"}
+    mock_get_repository_root.return_value = str(tmp_path / "repo")
+    mock_generate.return_value = tmp_path / "output"
+    context = OrderedDict({"title": "Test", "_template": "/some/path"})
+
+    with pytest.warns(DeprecationWarning, match="generate_subtemplate.*deprecated"):
+        generate_subtemplate(
+            template_path="sub",
+            output_dir=tmp_path,
+            folder_name="my_folder",
+            context=context,
+        )
+
+
+def test_does_not_warn_when_in_quiet_mode(
+    mock_remove_internal_keys,
+    mock_get_repository_root,
+    mock_quiet_mode,
+    mock_generate,
+    tmp_path,
+    monkeypatch,
+):
+    """DeprecationWarning is suppressed when quiet mode is active."""
+    monkeypatch.setenv(QUIET_MODE_VAR, "1")
+    mock_remove_internal_keys.return_value = {"title": "Test"}
+    mock_get_repository_root.return_value = str(tmp_path / "repo")
+    mock_generate.return_value = tmp_path / "output"
+    context = OrderedDict({"title": "Test", "_template": "/some/path"})
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        generate_subtemplate(
+            template_path="sub",
+            output_dir=tmp_path,
+            folder_name="my_folder",
+            context=context,
+        )
+    deprecation_warnings = [
+        w for w in captured if issubclass(w.category, DeprecationWarning)
+    ]
+    assert deprecation_warnings == []

--- a/tests/utils/test_subtemplates.py
+++ b/tests/utils/test_subtemplates.py
@@ -1,9 +1,18 @@
 """Tests for cookieplone.utils.subtemplates."""
 
+import os
+from collections import OrderedDict
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from cookieplone.config import CookieploneState
-from cookieplone.utils.subtemplates import process_subtemplates
+from cookieplone.settings import QUIET_MODE_VAR
+from cookieplone.utils.subtemplates import (
+    _parse_subtemplate_entry,
+    process_subtemplates,
+    run_subtemplates,
+)
 
 
 @pytest.fixture
@@ -102,3 +111,357 @@ class TestProcessSubtemplates:
         ])
         result = process_subtemplates(state, {})
         assert [r[0] for r in result] == ["c", "a", "b"]
+
+
+class TestParseSubtemplateEntry:
+    """Tests for _parse_subtemplate_entry."""
+
+    @pytest.mark.parametrize(
+        "entry,expected",
+        [
+            (
+                {"id": "sub/cache", "title": "Cache", "enabled": "1"},
+                {
+                    "id": "sub/cache",
+                    "title": "Cache",
+                    "enabled": "1",
+                    "folder_name": "",
+                },
+            ),
+            (
+                {
+                    "id": "sub/cache",
+                    "title": "Cache",
+                    "enabled": "1",
+                    "folder_name": ".",
+                },
+                {
+                    "id": "sub/cache",
+                    "title": "Cache",
+                    "enabled": "1",
+                    "folder_name": ".",
+                },
+            ),
+            (
+                {
+                    "id": "ci/gh_project",
+                    "title": "GitHub CI",
+                    "enabled": "1",
+                    "folder_name": ".github",
+                },
+                {
+                    "id": "ci/gh_project",
+                    "title": "GitHub CI",
+                    "enabled": "1",
+                    "folder_name": ".github",
+                },
+            ),
+        ],
+        ids=["dict-no-folder", "dict-dot-folder", "dict-with-folder"],
+    )
+    def test_dict_format(self, entry, expected):
+        """Dict entries are normalised correctly."""
+        assert _parse_subtemplate_entry(entry) == expected
+
+    @pytest.mark.parametrize(
+        "entry,expected",
+        [
+            (
+                ["sub/cache", "Cache", "1"],
+                {
+                    "id": "sub/cache",
+                    "title": "Cache",
+                    "enabled": "1",
+                    "folder_name": "",
+                },
+            ),
+            (
+                ("sub/cache", "Cache", "0"),
+                {
+                    "id": "sub/cache",
+                    "title": "Cache",
+                    "enabled": "0",
+                    "folder_name": "",
+                },
+            ),
+            (
+                ["ci/gh_project", "GitHub CI", "1", ".github"],
+                {
+                    "id": "ci/gh_project",
+                    "title": "GitHub CI",
+                    "enabled": "1",
+                    "folder_name": ".github",
+                },
+            ),
+        ],
+        ids=["list-3-items", "tuple-3-items", "list-4-items-with-folder"],
+    )
+    def test_tuple_format(self, entry, expected):
+        """Tuple/list entries are normalised correctly."""
+        assert _parse_subtemplate_entry(entry) == expected
+
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            ["only_two", "items"],
+            "a string",
+            42,
+        ],
+        ids=["short-list", "string", "int"],
+    )
+    def test_invalid_format_raises(self, entry):
+        """Invalid entries raise ValueError."""
+        with pytest.raises(ValueError, match="Unrecognized subtemplate entry format"):
+            _parse_subtemplate_entry(entry)
+
+
+class TestRunSubtemplates:
+    """Tests for run_subtemplates."""
+
+    @pytest.fixture
+    def context(self):
+        """A minimal cookiecutter context with subtemplates."""
+        return OrderedDict({
+            "title": "My Project",
+            "__cookieplone_repository_path": "repo",
+            "__cookieplone_subtemplates": [],
+        })
+
+    @pytest.fixture
+    def output_dir(self, tmp_path):
+        """A temporary output directory."""
+        project_dir = tmp_path / "my-project"
+        project_dir.mkdir()
+        return project_dir
+
+    def test_empty_subtemplates(self, context, output_dir):
+        """Returns empty dict when no subtemplates defined."""
+        result = run_subtemplates(context, output_dir)
+        assert result == {}
+
+    def test_missing_subtemplates_key(self, output_dir):
+        """Returns empty dict when __cookieplone_subtemplates is missing."""
+        context = OrderedDict({"title": "My Project"})
+        result = run_subtemplates(context, output_dir)
+        assert result == {}
+
+    @patch("cookieplone.utils.subtemplates.console_print")
+    def test_disabled_subtemplate_skipped(self, mock_print, context, output_dir):
+        """Disabled subtemplates are skipped with a log message."""
+        context["__cookieplone_subtemplates"] = [
+            {
+                "id": "sub/cache",
+                "title": "Cache structure",
+                "enabled": "0",
+                "folder_name": ".",
+            },
+        ]
+        result = run_subtemplates(context, output_dir)
+        assert result == {}
+        mock_print.assert_called_once_with(" -> Ignoring (Cache structure)")
+
+    @patch("cookieplone.generator.generate_subtemplate")
+    @patch("cookieplone.utils.subtemplates.console_print")
+    def test_enabled_without_handler_calls_default(
+        self, mock_print, mock_generate, context, output_dir
+    ):
+        """Enabled subtemplate without handler calls generate_subtemplate."""
+        generated_path = output_dir / "backend"
+        mock_generate.return_value = generated_path
+        context["__cookieplone_subtemplates"] = [
+            {
+                "id": "add-ons/backend",
+                "title": "Backend add-on",
+                "enabled": "1",
+                "folder_name": "backend",
+            },
+        ]
+        result = run_subtemplates(context, output_dir)
+        assert result == {"add-ons/backend": generated_path}
+        mock_generate.assert_called_once()
+        call_kwargs = mock_generate.call_args
+        assert call_kwargs.kwargs["template_path"] == "templates/add-ons/backend"
+        assert call_kwargs.kwargs["output_dir"] == output_dir
+        assert call_kwargs.kwargs["folder_name"] == "backend"
+
+    @patch("cookieplone.generator.generate_subtemplate")
+    @patch("cookieplone.utils.subtemplates.console_print")
+    def test_dot_folder_name_merges_into_project(
+        self, mock_print, mock_generate, context, output_dir
+    ):
+        """folder_name '.' generates into parent dir with project name."""
+        generated_path = output_dir
+        mock_generate.return_value = generated_path
+        context["__cookieplone_subtemplates"] = [
+            {
+                "id": "sub/cache",
+                "title": "Cache",
+                "enabled": "1",
+                "folder_name": ".",
+            },
+        ]
+        result = run_subtemplates(context, output_dir)
+        assert result == {"sub/cache": generated_path}
+        call_kwargs = mock_generate.call_args
+        assert call_kwargs.kwargs["output_dir"] == output_dir.parent
+        assert call_kwargs.kwargs["folder_name"] == output_dir.name
+
+    @patch("cookieplone.utils.subtemplates.console_print")
+    def test_handler_called_for_matching_id(self, mock_print, context, output_dir):
+        """Custom handler is called when template_id matches."""
+        handler = MagicMock(return_value=output_dir / "frontend")
+        context["__cookieplone_subtemplates"] = [
+            {
+                "id": "add-ons/frontend",
+                "title": "Frontend add-on",
+                "enabled": "1",
+                "folder_name": "frontend",
+            },
+        ]
+        result = run_subtemplates(
+            context, output_dir, handlers={"add-ons/frontend": handler}
+        )
+        assert result == {"add-ons/frontend": output_dir / "frontend"}
+        handler.assert_called_once()
+        # Handler receives a deep copy, not the original context
+        call_args = handler.call_args[0]
+        assert call_args[0] is not context
+        assert call_args[0] == context
+        assert call_args[1] == output_dir
+
+    @patch("cookieplone.generator.generate_subtemplate")
+    @patch("cookieplone.utils.subtemplates.console_print")
+    def test_mixed_handlers_and_defaults(
+        self, mock_print, mock_generate, context, output_dir
+    ):
+        """Mix of custom handlers and default generation."""
+        handler = MagicMock(return_value=output_dir / "frontend")
+        mock_generate.return_value = output_dir / "backend"
+        context["__cookieplone_subtemplates"] = [
+            {
+                "id": "add-ons/backend",
+                "title": "Backend",
+                "enabled": "1",
+                "folder_name": "backend",
+            },
+            {
+                "id": "add-ons/frontend",
+                "title": "Frontend",
+                "enabled": "1",
+                "folder_name": "frontend",
+            },
+            {
+                "id": "sub/cache",
+                "title": "Cache",
+                "enabled": "0",
+                "folder_name": ".",
+            },
+        ]
+        result = run_subtemplates(
+            context, output_dir, handlers={"add-ons/frontend": handler}
+        )
+        assert "add-ons/backend" in result
+        assert "add-ons/frontend" in result
+        assert "sub/cache" not in result  # disabled
+        mock_generate.assert_called_once()  # backend only
+        handler.assert_called_once()  # frontend only
+
+    @patch("cookieplone.generator.generate_subtemplate")
+    @patch("cookieplone.utils.subtemplates.console_print")
+    def test_preserves_order(self, mock_print, mock_generate, context, output_dir):
+        """Results preserve the order of subtemplates."""
+        mock_generate.side_effect = [
+            output_dir / "a",
+            output_dir / "b",
+            output_dir / "c",
+        ]
+        context["__cookieplone_subtemplates"] = [
+            {"id": "z", "title": "Z", "enabled": "1", "folder_name": "a"},
+            {"id": "m", "title": "M", "enabled": "1", "folder_name": "b"},
+            {"id": "a", "title": "A", "enabled": "1", "folder_name": "c"},
+        ]
+        result = run_subtemplates(context, output_dir)
+        assert list(result.keys()) == ["z", "m", "a"]
+
+    @patch("cookieplone.generator.generate_subtemplate")
+    @patch("cookieplone.utils.subtemplates.console_print")
+    def test_tuple_format_entries(self, mock_print, mock_generate, context, output_dir):
+        """Legacy tuple format entries work correctly."""
+        mock_generate.return_value = output_dir
+        context["__cookieplone_subtemplates"] = [
+            ["sub/cache", "Cache", "1"],
+        ]
+        result = run_subtemplates(context, output_dir)
+        assert "sub/cache" in result
+        # No folder_name in tuple → empty → falls back to output_dir.name
+        call_kwargs = mock_generate.call_args
+        assert call_kwargs.kwargs["folder_name"] == output_dir.name
+
+    @patch("cookieplone.generator.generate_subtemplate")
+    @patch("cookieplone.utils.subtemplates.console_print")
+    def test_no_folder_name_uses_output_dir_name(
+        self, mock_print, mock_generate, context, output_dir
+    ):
+        """Missing folder_name falls back to output_dir.name."""
+        mock_generate.return_value = output_dir
+        context["__cookieplone_subtemplates"] = [
+            {"id": "sub/settings", "title": "Settings", "enabled": "1"},
+        ]
+        run_subtemplates(context, output_dir)
+        call_kwargs = mock_generate.call_args
+        assert call_kwargs.kwargs["output_dir"] == output_dir
+        assert call_kwargs.kwargs["folder_name"] == output_dir.name
+
+    @patch("cookieplone.utils.subtemplates.console_print")
+    def test_handler_dispatch_runs_in_quiet_mode(
+        self, mock_print, context, output_dir, monkeypatch
+    ):
+        """Each handler is invoked with QUIET_MODE_VAR active."""
+        monkeypatch.delenv(QUIET_MODE_VAR, raising=False)
+        observed: list[bool] = []
+
+        def spy_handler(_context, _output_dir):
+            observed.append(os.environ.get(QUIET_MODE_VAR) == "1")
+            return _output_dir / "generated"
+
+        context["__cookieplone_subtemplates"] = [
+            {
+                "id": "add-ons/backend",
+                "title": "Backend",
+                "enabled": "1",
+                "folder_name": "backend",
+            },
+            {
+                "id": "add-ons/frontend",
+                "title": "Frontend",
+                "enabled": "1",
+                "folder_name": "frontend",
+            },
+        ]
+        run_subtemplates(
+            context,
+            output_dir,
+            handlers={
+                "add-ons/backend": spy_handler,
+                "add-ons/frontend": spy_handler,
+            },
+        )
+        assert observed == [True, True]
+
+    @patch("cookieplone.utils.subtemplates.console_print")
+    def test_quiet_mode_disabled_after_completion(
+        self, mock_print, context, output_dir, monkeypatch
+    ):
+        """Quiet mode is cleared after run_subtemplates returns."""
+        monkeypatch.delenv(QUIET_MODE_VAR, raising=False)
+        handler = MagicMock(return_value=output_dir / "generated")
+        context["__cookieplone_subtemplates"] = [
+            {
+                "id": "add-ons/backend",
+                "title": "Backend",
+                "enabled": "1",
+                "folder_name": "backend",
+            },
+        ]
+        run_subtemplates(context, output_dir, handlers={"add-ons/backend": handler})
+        assert QUIET_MODE_VAR not in os.environ


### PR DESCRIPTION
## Summary

- Adds `cookieplone.utils.subtemplates.run_subtemplates()`, a helper that post-generation hooks can use to drive sub-template generation via an explicit `{template_id: handler}` dispatch dict, with a default fallback for entries that do not need custom handling.
- Accepts both the legacy `[id, title, enabled]` tuple format and a new dict format with an optional `folder_name` key, so templates can migrate incrementally.
- Deprecates the legacy `cookieplone.generator.generate_subtemplate()` entry point. The `DeprecationWarning` is suppressed when Cookieplone is running in quiet mode, so `run_subtemplates()` does not spam the parent run's UI when it dispatches to the default fallback.
- Documents the new pattern in the concepts page and a new how-to guide that walks through the `monorepo` project template as a reference implementation.

## Why

Every monorepo-style template used to duplicate the same boilerplate loop in `post_gen_project.py`:

```python
funcs = {k: v for k, v in globals().items() if k.startswith("generate_")}
for template_id, title, enabled in subtemplates:
    template_slug = template_id.replace("/", "_").replace("-", "")
    func_name = f"generate_{template_slug}"
    func = funcs.get(func_name)
    if not func:
        raise ValueError(...)
    ...
```

This relied on name munging, `globals()` scraping, and a hard error when a handler was missing. With `run_subtemplates()`, the dispatch is explicit, testable, and can fall through to a default generator when no customization is needed.

## Changes

### New public API

- `cookieplone.utils.subtemplates.run_subtemplates(context, output_dir, handlers=None) -> dict[str, Path]`
- `cookieplone.utils.subtemplates.SubtemplateHandler` — `Callable[[OrderedDict, Path], Path]` type alias for handler functions.
- Each dispatch runs inside `quiet_mode()` so that nested `generate_subtemplate()` output and deprecation warnings stay out of the parent run's console.

### Deprecation

- `cookieplone.generator.generate_subtemplate()` now emits a `DeprecationWarning` pointing at `run_subtemplates()`. The warning is gated on `QUIET_MODE_VAR` so it only fires for direct user calls.

### Documentation

- Rewrote the "Calling sub-templates from a hook" section in `docs/src/concepts/subtemplates.md` to describe the new helper, its three dispatch paths, and how handlers receive deep-copied contexts.
- Added a new how-to guide `docs/src/how-to-guides/call-subtemplates-from-a-hook.md` that walks through four handler patterns (simple, post-processing, composed context, output-dir rewrite) drawn from the `monorepo` template in `plone/cookieplone-templates`.
- Linked the new guide from the concepts page and registered it in the how-to-guides index.
- Added `monorepo` to the Plone vocabulary so vale does not flag it in docs.

### Tests

- Extended `tests/utils/test_subtemplates.py` with `TestRunSubtemplates` tests covering: empty context, missing key, disabled skip, default-fallback call, `folder_name="."` merge, custom handler dispatch, mixed handler/default mix, tuple format compatibility, ordering, and deep-copy isolation.
- Added regression tests asserting that `run_subtemplates()` activates `QUIET_MODE_VAR` during handler dispatch and clears it on return.
- Added regression tests for `generate_subtemplate()` confirming the deprecation warning fires outside quiet mode and is suppressed inside it.

## Follow-up

`plone/cookieplone-templates` needs a matching PR on the `next` branch to refactor the all template's `post_gen_project.py` to use `run_subtemplates()` and the `SUBTEMPLATE_HANDLERS` dispatch dict. That change is ready locally and will land after this PR merges.

Closes #119