### PR TITLE
Align ruff isort configuration with other Plone projects

### DIFF
--- a/cookieplone/__main__.py
+++ b/cookieplone/__main__.py
@@ -5,5 +5,6 @@
 
 from cookieplone.cli import main
 
+
 if __name__ == "__main__":  # pragma: no cover
     main()

--- a/cookieplone/_types.py
+++ b/cookieplone/_types.py
@@ -1,4 +1,5 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from dataclasses import field
 from pathlib import Path
 from typing import Any
 

--- a/cookieplone/cli/__init__.py
+++ b/cookieplone/cli/__init__.py
@@ -3,26 +3,29 @@
 # SPDX-License-Identifier: MIT
 """Main `cookieplone` CLI."""
 
-import os
+from cookieplone import _types as t
+from cookieplone import data
+from cookieplone import settings
+from cookieplone._types import GenerateConfig
+from cookieplone.exceptions import GeneratorException
+from cookieplone.exceptions import PreFlightException
+from cookieplone.generator import generate
+from cookieplone.logger import configure_logger
+from cookieplone.logger import logger
+from cookieplone.repository import get_base_repository
+from cookieplone.repository import get_template_groups
+from cookieplone.repository import get_template_options
+from cookieplone.utils import console
+from cookieplone.utils import files
+from cookieplone.utils import internal
 from copy import deepcopy
 from pathlib import Path
-from typing import Annotated, Any
-
-import typer
 from rich.prompt import Prompt
+from typing import Annotated
+from typing import Any
 
-from cookieplone import _types as t
-from cookieplone import data, settings
-from cookieplone._types import GenerateConfig
-from cookieplone.exceptions import GeneratorException, PreFlightException
-from cookieplone.generator import generate
-from cookieplone.logger import configure_logger, logger
-from cookieplone.repository import (
-    get_base_repository,
-    get_template_groups,
-    get_template_options,
-)
-from cookieplone.utils import console, files, internal
+import os
+import typer
 
 
 def validate_extra_context(value: list[str] | None = None) -> list[str]:

--- a/cookieplone/cli/converter.py
+++ b/cookieplone/cli/converter.py
@@ -3,12 +3,13 @@
 # SPDX-License-Identifier: MIT
 """Converter CLI."""
 
+from cookieplone.utils import config
+from cookieplone.utils import console
 from pathlib import Path
 from typing import Annotated
 
 import typer
 
-from cookieplone.utils import config, console
 
 app = typer.Typer()
 

--- a/cookieplone/config/__init__.py
+++ b/cookieplone/config/__init__.py
@@ -2,8 +2,11 @@
 #
 # SPDX-License-Identifier: MIT
 
-from cookieplone.config.state import Answers, CookieploneState, generate_state
+from cookieplone.config.state import Answers
+from cookieplone.config.state import CookieploneState
+from cookieplone.config.state import generate_state
 from cookieplone.config.user import get_user_config
+
 
 __all__ = [
     "Answers",

--- a/cookieplone/config/schemas/__init__.py
+++ b/cookieplone/config/schemas/__init__.py
@@ -9,19 +9,14 @@ Defines JSON Schemas and validation helpers for:
   describes form fields and generator settings.
 """
 
-from cookieplone.config.schemas._types import (
-    SubTemplate,
-    TemplateEntry,
-    TemplateGroup,
-)
-from cookieplone.config.schemas.repository import (
-    REPOSITORY_CONFIG_SCHEMA,
-    validate_repository_config,
-)
-from cookieplone.config.schemas.template import (
-    COOKIEPLONE_CONFIG_SCHEMA,
-    validate_cookieplone_config,
-)
+from cookieplone.config.schemas._types import SubTemplate
+from cookieplone.config.schemas._types import TemplateEntry
+from cookieplone.config.schemas._types import TemplateGroup
+from cookieplone.config.schemas.repository import REPOSITORY_CONFIG_SCHEMA
+from cookieplone.config.schemas.repository import validate_repository_config
+from cookieplone.config.schemas.template import COOKIEPLONE_CONFIG_SCHEMA
+from cookieplone.config.schemas.template import validate_cookieplone_config
+
 
 __all__ = [
     "COOKIEPLONE_CONFIG_SCHEMA",

--- a/cookieplone/config/schemas/repository.py
+++ b/cookieplone/config/schemas/repository.py
@@ -1,11 +1,12 @@
 """Validation for the repository-level ``cookieplone-config.json`` format."""
 
-import json
+from jsonschema.exceptions import ValidationError
 from pathlib import Path
 from typing import Any
 
+import json
 import jsonschema
-from jsonschema.exceptions import ValidationError
+
 
 _SCHEMA_PATH = Path(__file__).parent / "repository_config.schema.json"
 REPOSITORY_CONFIG_SCHEMA: dict[str, Any] = json.loads(_SCHEMA_PATH.read_text())

--- a/cookieplone/config/schemas/template.py
+++ b/cookieplone/config/schemas/template.py
@@ -1,11 +1,12 @@
 """Validation for the per-template ``cookieplone.json`` v2 format."""
 
-import json
+from jsonschema.exceptions import ValidationError
 from pathlib import Path
 from typing import Any
 
+import json
 import jsonschema
-from jsonschema.exceptions import ValidationError
+
 
 _SCHEMA_PATH = Path(__file__).parent / "cookieplone_config.schema.json"
 COOKIEPLONE_CONFIG_SCHEMA: dict[str, Any] = json.loads(_SCHEMA_PATH.read_text())

--- a/cookieplone/config/state.py
+++ b/cookieplone/config/state.py
@@ -1,16 +1,19 @@
-import warnings
-from dataclasses import dataclass, field
+from cookiecutter import exceptions as exc
+from cookieplone.config.schemas import SubTemplate
+from cookieplone.config.v1 import parse_v1
+from cookieplone.config.v2 import ParsedConfig
+from cookieplone.config.v2 import parse_v2
+from cookieplone.logger import logger
+from cookieplone.settings import DEFAULT_DATA_KEY
+from cookieplone.settings import DEFAULT_VALIDATORS
+from cookieplone.utils import files as f
+from dataclasses import dataclass
+from dataclasses import field
 from pathlib import Path
 from typing import Any
 
-from cookiecutter import exceptions as exc
+import warnings
 
-from cookieplone.config.schemas import SubTemplate
-from cookieplone.config.v1 import parse_v1
-from cookieplone.config.v2 import ParsedConfig, parse_v2
-from cookieplone.logger import logger
-from cookieplone.settings import DEFAULT_DATA_KEY, DEFAULT_VALIDATORS
-from cookieplone.utils import files as f
 
 _NO_VALUE = object()
 

--- a/cookieplone/config/user.py
+++ b/cookieplone/config/user.py
@@ -1,15 +1,15 @@
-import os
-from copy import deepcopy
-from pathlib import Path
-from typing import Any
-
-import yaml
 from cookiecutter import config
-
 from cookieplone.exceptions import InvalidConfiguration
 from cookieplone.logger import logger
 from cookieplone.settings import DEFAULT_CONFIG
 from cookieplone.utils.git import get_user_info
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import os
+import yaml
+
 
 USER_CONFIG_ENVS = ["COOKIEPLONE_CONFIG", "COOKIECUTTER_CONFIG"]
 

--- a/cookieplone/config/v1.py
+++ b/cookieplone/config/v1.py
@@ -23,10 +23,9 @@
 ```
 """
 
-from typing import Any
-
 from cookieplone.config.v2 import ParsedConfig
 from cookieplone.utils.config import convert_v1_to_v2
+from typing import Any
 
 
 def parse_v1(context: dict[str, Any]) -> ParsedConfig:

--- a/cookieplone/config/v2.py
+++ b/cookieplone/config/v2.py
@@ -21,10 +21,10 @@ The v2 format separates form schema from generator configuration::
     }
 """
 
-from dataclasses import dataclass, field
-from typing import Any
-
 from cookieplone.config.schemas import SubTemplate
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
 
 
 @dataclass

--- a/cookieplone/data.py
+++ b/cookieplone/data.py
@@ -4,7 +4,10 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal, TypeAlias
+from typing import Any
+from typing import Literal
+from typing import TypeAlias
+
 
 OptionalPath: TypeAlias = Path | None
 OptionalListStr: TypeAlias = list[str] | None

--- a/cookieplone/exceptions.py
+++ b/cookieplone/exceptions.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
 
+from cookiecutter import exceptions as exc
 from typing import TYPE_CHECKING
 
-from cookiecutter import exceptions as exc
 
 if TYPE_CHECKING:
     from cookieplone.config.state import CookieploneState

--- a/cookieplone/filters/__init__.py
+++ b/cookieplone/filters/__init__.py
@@ -1,12 +1,13 @@
 # SPDX-FileCopyrightText: 2024-present Plone Foundation <board@plone.org>
 #
 # SPDX-License-Identifier: MIT
-import os
-
 from cookiecutter.utils import simple_filter
-
-from cookieplone.utils import containers, npm, versions
+from cookieplone.utils import containers
+from cookieplone.utils import npm
+from cookieplone.utils import versions
 from cookieplone.utils.parsers import parse_boolean
+
+import os
 
 
 @simple_filter

--- a/cookieplone/generator/__init__.py
+++ b/cookieplone/generator/__init__.py
@@ -2,26 +2,28 @@
 #
 # SPDX-License-Identifier: MIT
 
-import os
-import warnings
 from collections import OrderedDict
-from pathlib import Path
-
 from cookiecutter import exceptions as exc
-
 from cookieplone._types import GenerateConfig
-from cookieplone.config import Answers, CookieploneState, generate_state
-from cookieplone.exceptions import (
-    FailedHookException,
-    GeneratorException,
-    RepositoryException,
-)
+from cookieplone.config import Answers
+from cookieplone.config import CookieploneState
+from cookieplone.config import generate_state
+from cookieplone.exceptions import FailedHookException
+from cookieplone.exceptions import GeneratorException
+from cookieplone.exceptions import RepositoryException
 from cookieplone.generator.main import cookieplone
 from cookieplone.repository import get_repository
-from cookieplone.settings import COOKIEPLONE_ANSWERS_FILE, QUIET_MODE_VAR
-from cookieplone.utils import answers, cookiecutter, files
+from cookieplone.settings import COOKIEPLONE_ANSWERS_FILE
+from cookieplone.settings import QUIET_MODE_VAR
+from cookieplone.utils import answers
+from cookieplone.utils import cookiecutter
+from cookieplone.utils import files
 from cookieplone.utils.console import quiet_mode
 from cookieplone.utils.cookiecutter import load_replay
+from pathlib import Path
+
+import os
+import warnings
 
 
 def _dump_answers(answers_: Answers, template_name: str, no_input: bool = False):

--- a/cookieplone/generator/main.py
+++ b/cookieplone/generator/main.py
@@ -1,25 +1,23 @@
 # SPDX-FileCopyrightText: 2024-present Plone Foundation <board@plone.org>
 #
 # SPDX-License-Identifier: MIT
-from pathlib import Path
-from typing import Any
-
 from cookiecutter import exceptions as exc
 from cookiecutter.generate import generate_files
-from jinja2.exceptions import UndefinedError
-
-from cookieplone._types import RepositoryInfo, RunConfig
+from cookieplone._types import RepositoryInfo
+from cookieplone._types import RunConfig
 from cookieplone.config import CookieploneState
-from cookieplone.exceptions import GeneratorException, OutputDirExistsException
+from cookieplone.exceptions import GeneratorException
+from cookieplone.exceptions import OutputDirExistsException
 from cookieplone.utils import files as f
 from cookieplone.utils.answers import remove_internal_keys
-from cookieplone.utils.cookiecutter import (
-    import_patch,
-    parse_output_dir_exception,
-    parse_undefined_error,
-)
+from cookieplone.utils.cookiecutter import import_patch
+from cookieplone.utils.cookiecutter import parse_output_dir_exception
+from cookieplone.utils.cookiecutter import parse_undefined_error
 from cookieplone.utils.subtemplates import process_subtemplates
 from cookieplone.wizard import wizard
+from jinja2.exceptions import UndefinedError
+from pathlib import Path
+from typing import Any
 
 
 def _annotate_data(

--- a/cookieplone/logger.py
+++ b/cookieplone/logger.py
@@ -1,8 +1,10 @@
+from cookiecutter.log import LOG_FORMATS
+from cookiecutter.log import LOG_LEVELS
+from cookiecutter.log import configure_logger as cookicutter_logger
+
 import logging
 import sys
 
-from cookiecutter.log import LOG_FORMATS, LOG_LEVELS
-from cookiecutter.log import configure_logger as cookicutter_logger
 
 logger = logging.getLogger("cookieplone")
 

--- a/cookieplone/repository.py
+++ b/cookieplone/repository.py
@@ -1,21 +1,19 @@
 # SPDX-FileCopyrightText: 2024-present Plone Foundation <board@plone.org>
 #
 # SPDX-License-Identifier: MIT
-import json
-from pathlib import Path
-from typing import Any
-
 from cookiecutter import exceptions as exc
 from cookiecutter import repository as base
-
 from cookieplone import _types as t
 from cookieplone import data
 from cookieplone.config import get_user_config
-from cookieplone.exceptions import (
-    PreFlightException,
-    RepositoryException,
-    RepositoryNotFound,
-)
+from cookieplone.exceptions import PreFlightException
+from cookieplone.exceptions import RepositoryException
+from cookieplone.exceptions import RepositoryNotFound
+from pathlib import Path
+from typing import Any
+
+import json
+
 
 REPO_CONFIG_FILENAME = "cookieplone-config.json"
 

--- a/cookieplone/templates/bake.py
+++ b/cookieplone/templates/bake.py
@@ -1,14 +1,12 @@
+from cookieplone._types import RunConfig
+from cookieplone.config import CookieploneState
+from cookieplone.config import generate_state
+from cookieplone.generator.main import cookieplone
+from cookieplone.repository import REPO_CONFIG_FILENAME
+from cookieplone.repository import get_repository
+from cookieplone.repository import get_repository_config
 from dataclasses import dataclass
 from pathlib import Path
-
-from cookieplone._types import RunConfig
-from cookieplone.config import CookieploneState, generate_state
-from cookieplone.generator.main import cookieplone
-from cookieplone.repository import (
-    REPO_CONFIG_FILENAME,
-    get_repository,
-    get_repository_config,
-)
 
 
 def _discover_global_versions(template_path: Path) -> dict[str, str]:

--- a/cookieplone/templates/fixtures.py
+++ b/cookieplone/templates/fixtures.py
@@ -1,14 +1,13 @@
-import json
-import re
+from .bake import Cookies
+from binaryornot.check import is_binary
+from cookieplone.templates import types
 from pathlib import Path
 
+import json
 import pytest
+import re
 import yaml
-from binaryornot.check import is_binary
 
-from cookieplone.templates import types
-
-from .bake import Cookies
 
 IGNORED_KEYS = (
     "_extensions",

--- a/cookieplone/templates/types.py
+++ b/cookieplone/templates/types.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Protocol
 
+
 StrPath = str | Path
 DataStructure = dict | list
 

--- a/cookieplone/utils/__init__.py
+++ b/cookieplone/utils/__init__.py
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: MIT
 from cookiecutter.utils import rmtree
 
+
 __all__ = ["rmtree"]

--- a/cookieplone/utils/answers.py
+++ b/cookieplone/utils/answers.py
@@ -1,11 +1,10 @@
 from collections import OrderedDict
-from copy import deepcopy
-from pathlib import Path
-from typing import Any
-
 from cookieplone.config import Answers
 from cookieplone.settings import CONFIG_COMPUTED_KEYS
 from cookieplone.utils import files
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
 
 
 def remove_internal_keys(raw_answers: OrderedDict[str, Any] | dict[str, Any]) -> dict:

--- a/cookieplone/utils/commands/__init__.py
+++ b/cookieplone/utils/commands/__init__.py
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: 2024-present Plone Foundation <board@plone.org>
 #
 # SPDX-License-Identifier: MIT
+from cookieplone import settings
+
 import re
 import subprocess
 import sys
-
-from cookieplone import settings
 
 
 def _get_command_version(cmd: str) -> str:

--- a/cookieplone/utils/config.py
+++ b/cookieplone/utils/config.py
@@ -61,11 +61,11 @@ Version 2 (cookieplone.json) configuration format.
 """
 
 from collections import OrderedDict
-from dataclasses import dataclass, field
+from cookieplone.utils import files
+from dataclasses import dataclass
+from dataclasses import field
 from pathlib import Path
 from typing import Any
-
-from cookieplone.utils import files
 
 
 @dataclass

--- a/cookieplone/utils/console.py
+++ b/cookieplone/utils/console.py
@@ -1,24 +1,25 @@
 # SPDX-FileCopyrightText: 2024-present Plone Foundation <board@plone.org>
 #
 # SPDX-License-Identifier: MIT
-import os
+from .internal import cookieplone_info
+from .internal import version_info
 from collections.abc import Sequence
 from contextlib import contextmanager
+from cookieplone import _types as t
+from cookieplone.settings import QUIET_MODE_VAR
 from pathlib import Path
-from textwrap import dedent
-
 from rich import print as base_print
 from rich.align import Align
-from rich.console import Console, Group
+from rich.console import Console
+from rich.console import Group
 from rich.markup import escape
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
+from textwrap import dedent
 
-from cookieplone import _types as t
-from cookieplone.settings import QUIET_MODE_VAR
+import os
 
-from .internal import cookieplone_info, version_info
 
 _console = Console()
 

--- a/cookieplone/utils/cookiecutter.py
+++ b/cookieplone/utils/cookiecutter.py
@@ -1,22 +1,25 @@
 from __future__ import annotations
 
-import os
-import sys
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
+from contextlib import suppress
 from copy import copy
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+import os
+import sys
+
 
 if TYPE_CHECKING:
     from jinja2 import Environment
 
 from cookiecutter.exceptions import OutputDirExistsException
-from cookiecutter.replay import dump, load
+from cookiecutter.replay import dump
+from cookiecutter.replay import load
 from cookiecutter.utils import create_env_with_context
-from jinja2.exceptions import UndefinedError
-
 from cookieplone.config import Answers
 from cookieplone.settings import DEFAULT_DATA_KEY
+from jinja2.exceptions import UndefinedError
 
 
 @contextmanager

--- a/cookieplone/utils/files.py
+++ b/cookieplone/utils/files.py
@@ -1,14 +1,13 @@
 # SPDX-FileCopyrightText: 2024-present Plone Foundation <board@plone.org>
 #
 # SPDX-License-Identifier: MIT
-import json
 from collections import OrderedDict
+from cookiecutter.utils import rmtree
+from cookieplone import exceptions as exc
 from pathlib import Path
 from typing import Any
 
-from cookiecutter.utils import rmtree
-
-from cookieplone import exceptions as exc
+import json
 
 
 def resolve_path(path: Path | str) -> Path:

--- a/cookieplone/utils/formatters.py
+++ b/cookieplone/utils/formatters.py
@@ -1,7 +1,7 @@
-import subprocess
+from cookieplone.logger import logger
 from pathlib import Path
 
-from cookieplone.logger import logger
+import subprocess
 
 
 def _uvx(tool: str, args: list[str], base_path: Path) -> None:

--- a/cookieplone/utils/git.py
+++ b/cookieplone/utils/git.py
@@ -1,14 +1,16 @@
 # SPDX-FileCopyrightText: 2024-present Plone Foundation <board@plone.org>
 #
 # SPDX-License-Identifier: MIT
+from cookieplone.logger import logger
 from dataclasses import dataclass
+from git import Commit
+from git import Git
+from git import GitConfigParser
+from git import Repo
+from git.exc import GitCommandError
+from git.exc import InvalidGitRepositoryError
 from pathlib import Path
 from typing import cast
-
-from git import Commit, Git, GitConfigParser, Repo
-from git.exc import GitCommandError, InvalidGitRepositoryError
-
-from cookieplone.logger import logger
 
 
 @dataclass

--- a/cookieplone/utils/internal.py
+++ b/cookieplone/utils/internal.py
@@ -1,14 +1,15 @@
 # SPDX-FileCopyrightText: 2024-present Plone Foundation <board@plone.org>
 #
 # SPDX-License-Identifier: MIT
-import sys
+from cookiecutter import __version__ as __cookiecutter_version__
+from cookieplone import __version__
+from cookieplone import settings
+from cookieplone.utils import git
 from datetime import datetime
 from pathlib import Path
 
-from cookiecutter import __version__ as __cookiecutter_version__
+import sys
 
-from cookieplone import __version__, settings
-from cookieplone.utils import git
 
 SIGNATURE = (
     "Made with [bold][red]❤️[/red][/bold] by the"

--- a/cookieplone/utils/plone.py
+++ b/cookieplone/utils/plone.py
@@ -1,10 +1,9 @@
-import shutil
-from pathlib import Path
-
-import xmltodict
-
 from cookieplone.logger import logger
 from cookieplone.utils import formatters
+from pathlib import Path
+
+import shutil
+import xmltodict
 
 
 def add_dependency_profile_to_metadata(profile: str, raw_xml: str) -> str:

--- a/cookieplone/utils/subtemplates.py
+++ b/cookieplone/utils/subtemplates.py
@@ -1,17 +1,18 @@
 """Helpers for post-generation hooks that orchestrate sub-template rendering."""
 
-import logging
 from collections import OrderedDict
 from collections.abc import Callable
-from copy import deepcopy
-from pathlib import Path
-from typing import Any
-
 from cookieplone.config import CookieploneState
 from cookieplone.settings import TEMPLATES_FOLDER
 from cookieplone.utils.console import print as console_print
 from cookieplone.utils.console import quiet_mode
 from cookieplone.utils.cookiecutter import create_jinja_env
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import logging
+
 
 logger = logging.getLogger(__name__)
 

--- a/cookieplone/utils/validators.py
+++ b/cookieplone/utils/validators.py
@@ -1,13 +1,14 @@
 # SPDX-FileCopyrightText: 2024-present Plone Foundation <board@plone.org>
 #
 # SPDX-License-Identifier: MIT
-import re
+from cookieplone import data
+from cookieplone import settings
+from packaging.version import InvalidVersion
+from packaging.version import Version
 from typing import Any
 from urllib.parse import urlparse
 
-from packaging.version import InvalidVersion, Version
-
-from cookieplone import data, settings
+import re
 
 
 def _version_from_str(value: str) -> Version | None:

--- a/cookieplone/utils/versions.py
+++ b/cookieplone/utils/versions.py
@@ -1,13 +1,13 @@
 # SPDX-FileCopyrightText: 2024-present Plone Foundation <board@plone.org>
 #
 # SPDX-License-Identifier: MIT
-import re
-
-import requests
-import semver
+from cookieplone import settings
 from packaging.version import Version
 
-from cookieplone import settings
+import re
+import requests
+import semver
+
 
 VERSION_PATTERNS = (
     (r"^(a)(\d{1,2})", r"alpha.\2"),

--- a/cookieplone/validators/__init__.py
+++ b/cookieplone/validators/__init__.py
@@ -1,6 +1,5 @@
-from tui_forms.form.question import ValidationError
-
 from cookieplone.utils import validators
+from tui_forms.form.question import ValidationError
 
 
 def not_empty(value: str) -> bool:

--- a/cookieplone/wizard.py
+++ b/cookieplone/wizard.py
@@ -3,14 +3,19 @@
 # SPDX-License-Identifier: MIT
 """Implement the form wizard logic."""
 
-import os
+from cookieplone.config import Answers
+from cookieplone.config import CookieploneState
+from cookieplone.exceptions import InvalidConfiguration
+from cookieplone.settings import DEFAULT_EXTENSIONS
+from cookieplone.settings import DEFAULT_RENDERER
+from cookieplone.settings import RENDERER_VAR
+from tui_forms import available_renderers
+from tui_forms import create_form
+from tui_forms import get_renderer
 from typing import Any
 
-from tui_forms import available_renderers, create_form, get_renderer
+import os
 
-from cookieplone.config import Answers, CookieploneState
-from cookieplone.exceptions import InvalidConfiguration
-from cookieplone.settings import DEFAULT_EXTENSIONS, DEFAULT_RENDERER, RENDERER_VAR
 
 NOINPUT_RENDERER = "noinput"
 

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -5,9 +5,9 @@
 # -- Path setup --------------------------------------------------------------
 
 from datetime import datetime
-
 from packaging.version import Version
 from plone_sphinx_theme import __version__
+
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/news/171.internal
+++ b/news/171.internal
@@ -1,0 +1,1 @@
+Aligned ruff isort configuration with the rest of the Plone ecosystem: single-line, no-sections, `from`-first imports with two blank lines after the import block. Reformatted the entire codebase in one sweep. @ericof

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,14 @@ lint.ignore = [
 [tool.ruff.format]
 preview = true
 
+[tool.ruff.lint.isort]
+case-sensitive = false
+no-sections = true
+force-single-line = true
+from-first = true
+lines-after-imports = 2
+lines-between-types = 1
+
 [tool.ruff.lint.per-file-ignores]
 "cookieplone/utils/commands/__init__.py" = ["S603"]
 "tests/*" = ["S101"]

--- a/tests/cli/test_cli_converter.py
+++ b/tests/cli/test_cli_converter.py
@@ -1,9 +1,9 @@
+from cookieplone.cli.converter import app
 from pathlib import Path
-
-import pytest
 from typer.testing import CliRunner
 
-from cookieplone.cli.converter import app
+import pytest
+
 
 runner = CliRunner()
 

--- a/tests/config/test_schemas_repository.py
+++ b/tests/config/test_schemas_repository.py
@@ -1,9 +1,10 @@
 """Tests for cookieplone.config.schemas.repository."""
 
-import json
+from cookieplone.config.schemas import validate_repository_config
 from pathlib import Path
 
-from cookieplone.config.schemas import validate_repository_config
+import json
+
 
 RESOURCES = Path(__file__).parent.parent / "_resources" / "config"
 

--- a/tests/config/test_schemas_template.py
+++ b/tests/config/test_schemas_template.py
@@ -1,8 +1,8 @@
 """Tests for cookieplone.config.schemas.template."""
 
-import pytest
-
 from cookieplone.config.schemas import validate_cookieplone_config
+
+import pytest
 
 
 def _minimal_v2():

--- a/tests/config/test_state.py
+++ b/tests/config/test_state.py
@@ -1,7 +1,8 @@
-import pytest
-
 from cookieplone.config import CookieploneState
 from cookieplone.config import state as config
+
+import pytest
+
 
 CONFIG_FILES = [
     "config/v1-agents_instructions.json",

--- a/tests/config/test_state_versions.py
+++ b/tests/config/test_state_versions.py
@@ -1,9 +1,9 @@
 """Tests for version merging in cookieplone.config.state."""
 
-import pytest
-
 from cookieplone.config import state as config
 from cookieplone.config.v2 import ParsedConfig
+
+import pytest
 
 
 @pytest.mark.parametrize(

--- a/tests/config/test_user.py
+++ b/tests/config/test_user.py
@@ -1,9 +1,9 @@
+from cookieplone.config import user as config
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from cookieplone.config import user as config
 
 CONFIG_FILES: dict[str, dict] = {
     "badconfig.yml": {"src": "badconfig", "contents": {}},

--- a/tests/config/test_v1.py
+++ b/tests/config/test_v1.py
@@ -1,9 +1,8 @@
 """Tests for cookieplone.config.v1."""
 
-from typing import Any
-
 from cookieplone.config.v1 import parse_v1
 from cookieplone.config.v2 import ParsedConfig
+from typing import Any
 
 
 def test_returns_parsed_config():

--- a/tests/config/test_v2.py
+++ b/tests/config/test_v2.py
@@ -1,8 +1,8 @@
 """Tests for cookieplone.config.v2."""
 
+from cookieplone.config.v2 import ParsedConfig
+from cookieplone.config.v2 import parse_v2
 from typing import Any
-
-from cookieplone.config.v2 import ParsedConfig, parse_v2
 
 
 def test_returns_parsed_config():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,13 @@
+from collections.abc import Generator
+from git import Repo
+from pathlib import Path
+from pytest import MonkeyPatch
+
 import json
+import pytest
 import random
 import string
-from collections.abc import Generator
-from pathlib import Path
 
-import pytest
-from git import Repo
-from pytest import MonkeyPatch
 
 pytest_plugins = "pytester"
 

--- a/tests/generator/conftest.py
+++ b/tests/generator/conftest.py
@@ -1,11 +1,12 @@
 """Shared fixtures for generator tests."""
 
+from cookieplone._types import GenerateConfig
+from cookieplone._types import RepositoryInfo
+from cookieplone._types import RunConfig
+from cookieplone.config.state import CookieploneState
 from unittest.mock import MagicMock
 
 import pytest
-
-from cookieplone._types import GenerateConfig, RepositoryInfo, RunConfig
-from cookieplone.config.state import CookieploneState
 
 
 @pytest.fixture()

--- a/tests/generator/test_cookieplone.py
+++ b/tests/generator/test_cookieplone.py
@@ -1,10 +1,11 @@
 """Tests for the cookieplone exception-wrapping entry point."""
 
-import pytest
 from cookiecutter import exceptions as cc_exc
-
-from cookieplone.exceptions import GeneratorException, OutputDirExistsException
+from cookieplone.exceptions import GeneratorException
+from cookieplone.exceptions import OutputDirExistsException
 from cookieplone.generator.main import cookieplone
+
+import pytest
 
 
 def test_returns_path_on_success(

--- a/tests/generator/test_dump_answers.py
+++ b/tests/generator/test_dump_answers.py
@@ -1,9 +1,8 @@
 """Tests for _dump_answers."""
 
-from unittest.mock import MagicMock
-
 from cookieplone.config.state import Answers
 from cookieplone.generator import _dump_answers
+from unittest.mock import MagicMock
 
 
 def test_calls_write_answers(mock_write_answers, tmp_path):

--- a/tests/generator/test_generate.py
+++ b/tests/generator/test_generate.py
@@ -1,12 +1,12 @@
 """Tests for generate."""
 
+from cookiecutter import exceptions as cc_exc
+from cookieplone.exceptions import PreFlightException
+from cookieplone.exceptions import RepositoryException
+from cookieplone.generator import generate
 from dataclasses import replace
 
 import pytest
-from cookiecutter import exceptions as cc_exc
-
-from cookieplone.exceptions import PreFlightException, RepositoryException
-from cookieplone.generator import generate
 
 
 def test_replay_with_no_input_raises(generate_config):

--- a/tests/generator/test_generate_full.py
+++ b/tests/generator/test_generate_full.py
@@ -1,12 +1,11 @@
 """Tests for the generate() happy path and exception handling in __init__.py."""
 
-from dataclasses import replace
-
-import pytest
-
 from cookieplone.exceptions import GeneratorException
 from cookieplone.generator import generate
 from cookieplone.settings import COOKIEPLONE_ANSWERS_FILE
+from dataclasses import replace
+
+import pytest
 
 
 def test_happy_path_returns_path(
@@ -183,7 +182,8 @@ def test_failed_hook_reraised_as_repository_exception(
     generate_config,
 ):
     """FailedHookException from get_repository is wrapped in RepositoryException."""
-    from cookieplone.exceptions import FailedHookException, RepositoryException
+    from cookieplone.exceptions import FailedHookException
+    from cookieplone.exceptions import RepositoryException
 
     mock_get_repository.side_effect = FailedHookException("hook fail")
     with pytest.raises(RepositoryException, match="hook fail"):

--- a/tests/generator/test_generate_subtemplate.py
+++ b/tests/generator/test_generate_subtemplate.py
@@ -1,14 +1,13 @@
 """Tests for generate_subtemplate."""
 
-import warnings
 from collections import OrderedDict
-
-import pytest
-
 from cookieplone.config.state import CookieploneState
 from cookieplone.exceptions import GeneratorException
 from cookieplone.generator import generate_subtemplate
 from cookieplone.settings import QUIET_MODE_VAR
+
+import pytest
+import warnings
 
 
 def test_uses_quiet_mode(

--- a/tests/settings/test_plone_python.py
+++ b/tests/settings/test_plone_python.py
@@ -1,8 +1,8 @@
 """Tests for PLONE_PYTHON mapping."""
 
-import pytest
-
 from cookieplone import settings
+
+import pytest
 
 
 def test_plone_60_exists():

--- a/tests/templates/conftest.py
+++ b/tests/templates/conftest.py
@@ -1,6 +1,5 @@
-import shutil
-
 import pytest
+import shutil
 
 
 @pytest.fixture

--- a/tests/templates/test_bake.py
+++ b/tests/templates/test_bake.py
@@ -1,8 +1,7 @@
 """Regression tests for :mod:`cookieplone.templates.bake`."""
 
-from pathlib import Path
-
 from cookieplone.templates.bake import _discover_global_versions
+from pathlib import Path
 
 
 class TestDiscoverGlobalVersions:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
-import pytest
 from click.exceptions import BadParameter
-
 from cookieplone import cli
+
+import pytest
 
 
 @pytest.mark.parametrize(

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,15 +1,12 @@
 """Tests for cookieplone.exceptions."""
 
+from cookieplone.exceptions import CookieploneException
+from cookieplone.exceptions import GeneratorException
+from cookieplone.exceptions import OutputDirExistsException
+from cookieplone.exceptions import PreFlightException
 from unittest.mock import MagicMock
 
 import pytest
-
-from cookieplone.exceptions import (
-    CookieploneException,
-    GeneratorException,
-    OutputDirExistsException,
-    PreFlightException,
-)
 
 
 class TestCookieploneException:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,10 +1,9 @@
-import json
+from cookiecutter.generate import generate_context
+from cookieplone.utils.cookiecutter import create_jinja_env
 from pathlib import Path
 
+import json
 import pytest
-from cookiecutter.generate import generate_context
-
-from cookieplone.utils.cookiecutter import create_jinja_env
 
 
 @pytest.fixture

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,11 +1,10 @@
-import json
-from pathlib import Path
-
-import pytest
 from cookiecutter.exceptions import FailedHookException
-
 from cookieplone import repository
 from cookieplone.exceptions import PreFlightException
+from pathlib import Path
+
+import json
+import pytest
 
 
 @pytest.fixture

--- a/tests/utils/conftest.py
+++ b/tests/utils/conftest.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+
 STRUCTURE = [
     "templates",
     "templates/add-ons/backend",

--- a/tests/utils/test_answers.py
+++ b/tests/utils/test_answers.py
@@ -1,9 +1,8 @@
-import json
-
-import pytest
-
 from cookieplone.config.state import Answers
 from cookieplone.utils import answers
+
+import json
+import pytest
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_commands.py
+++ b/tests/utils/test_commands.py
@@ -1,8 +1,7 @@
-import sys
+from cookieplone.utils import commands
 
 import pytest
-
-from cookieplone.utils import commands
+import sys
 
 
 @pytest.fixture

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -1,6 +1,7 @@
+from cookieplone.utils import config
+
 import pytest
 
-from cookieplone.utils import config
 
 CONFIG_FILES = [
     "config/v1-agents_instructions.json",

--- a/tests/utils/test_console.py
+++ b/tests/utils/test_console.py
@@ -1,14 +1,14 @@
+from cookieplone._types import CookieploneTemplate
+from cookieplone._types import CookieploneTemplateGroup
+from cookieplone.settings import QUIET_MODE_VAR
+from cookieplone.utils import console
 from pathlib import Path
-from unittest.mock import patch
-
-import pytest
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
+from unittest.mock import patch
 
-from cookieplone._types import CookieploneTemplate, CookieploneTemplateGroup
-from cookieplone.settings import QUIET_MODE_VAR
-from cookieplone.utils import console
+import pytest
 
 
 @pytest.fixture

--- a/tests/utils/test_containers.py
+++ b/tests/utils/test_containers.py
@@ -1,6 +1,6 @@
-import pytest
-
 from cookieplone.utils import containers
+
+import pytest
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_cookiecutter.py
+++ b/tests/utils/test_cookiecutter.py
@@ -1,21 +1,18 @@
 """Tests for cookieplone.utils.cookiecutter."""
 
-import json
-import sys
-
-import pytest
 from cookiecutter.exceptions import OutputDirExistsException
+from cookieplone.utils.cookiecutter import create_jinja_env
+from cookieplone.utils.cookiecutter import dump_replay
+from cookieplone.utils.cookiecutter import import_patch
+from cookieplone.utils.cookiecutter import load_replay
+from cookieplone.utils.cookiecutter import parse_output_dir_exception
+from cookieplone.utils.cookiecutter import parse_undefined_error
 from jinja2 import Environment
 from jinja2.exceptions import UndefinedError
 
-from cookieplone.utils.cookiecutter import (
-    create_jinja_env,
-    dump_replay,
-    import_patch,
-    load_replay,
-    parse_output_dir_exception,
-    parse_undefined_error,
-)
+import json
+import pytest
+import sys
 
 
 class TestParseOutputDirException:

--- a/tests/utils/test_files.py
+++ b/tests/utils/test_files.py
@@ -1,9 +1,8 @@
+from cookieplone.exceptions import RepositoryNotFound
+from cookieplone.utils import files
 from pathlib import Path
 
 import pytest
-
-from cookieplone.exceptions import RepositoryNotFound
-from cookieplone.utils import files
 
 
 @pytest.fixture

--- a/tests/utils/test_formatters.py
+++ b/tests/utils/test_formatters.py
@@ -1,9 +1,8 @@
-import subprocess
+from cookieplone.utils import formatters
 from unittest.mock import patch
 
 import pytest
-
-from cookieplone.utils import formatters
+import subprocess
 
 
 class TestUvx:

--- a/tests/utils/test_git.py
+++ b/tests/utils/test_git.py
@@ -1,7 +1,8 @@
-import pytest
-from git import Commit, Repo
-
 from cookieplone.utils import git
+from git import Commit
+from git import Repo
+
+import pytest
 
 
 def test_repo_from_path(tmp_repo):

--- a/tests/utils/test_internal.py
+++ b/tests/utils/test_internal.py
@@ -1,12 +1,12 @@
-import re
-import sys
+from cookiecutter import __version__ as __cookiecutter_version__
+from cookieplone import __version__
+from cookieplone import settings
+from cookieplone.utils import internal
 from pathlib import Path
 
 import pytest
-from cookiecutter import __version__ as __cookiecutter_version__
-
-from cookieplone import __version__, settings
-from cookieplone.utils import internal
+import re
+import sys
 
 
 def test_version_info():

--- a/tests/utils/test_npm.py
+++ b/tests/utils/test_npm.py
@@ -1,6 +1,6 @@
-import pytest
-
 from cookieplone.utils import npm
+
+import pytest
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_parsers.py
+++ b/tests/utils/test_parsers.py
@@ -1,6 +1,6 @@
-import pytest
-
 from cookieplone.utils.parsers import parse_boolean
+
+import pytest
 
 
 class TestParseBoolean:

--- a/tests/utils/test_plone.py
+++ b/tests/utils/test_plone.py
@@ -1,6 +1,7 @@
+from cookieplone.utils import plone
+
 import pytest
 
-from cookieplone.utils import plone
 
 CONTENT = {
     "packagename": {

--- a/tests/utils/test_repository.py
+++ b/tests/utils/test_repository.py
@@ -1,10 +1,10 @@
-import json
-from pathlib import Path
-
-import pytest
-
 from cookieplone import _types as t
 from cookieplone import repository
+from pathlib import Path
+
+import json
+import pytest
+
 
 TEMPLATE_PARAMS = [
     (

--- a/tests/utils/test_sanity.py
+++ b/tests/utils/test_sanity.py
@@ -1,9 +1,8 @@
+from cookieplone import data
+from cookieplone.utils import sanity
 from typing import Any
 
 import pytest
-
-from cookieplone import data
-from cookieplone.utils import sanity
 
 
 def check_instance(value: Any, type_: type) -> str:

--- a/tests/utils/test_subtemplates.py
+++ b/tests/utils/test_subtemplates.py
@@ -1,18 +1,16 @@
 """Tests for cookieplone.utils.subtemplates."""
 
-import os
 from collections import OrderedDict
-from unittest.mock import MagicMock, patch
-
-import pytest
-
 from cookieplone.config import CookieploneState
 from cookieplone.settings import QUIET_MODE_VAR
-from cookieplone.utils.subtemplates import (
-    _parse_subtemplate_entry,
-    process_subtemplates,
-    run_subtemplates,
-)
+from cookieplone.utils.subtemplates import _parse_subtemplate_entry
+from cookieplone.utils.subtemplates import process_subtemplates
+from cookieplone.utils.subtemplates import run_subtemplates
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import os
+import pytest
 
 
 @pytest.fixture

--- a/tests/utils/test_utils_validators.py
+++ b/tests/utils/test_utils_validators.py
@@ -1,6 +1,6 @@
-import pytest
-
 from cookieplone.utils import validators
+
+import pytest
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_versions.py
+++ b/tests/utils/test_versions.py
@@ -1,7 +1,7 @@
-import pytest
-
 from cookieplone.settings import PythonVersionSupport
 from cookieplone.utils import versions
+
+import pytest
 
 
 @pytest.fixture

--- a/tests/validators/test_validators.py
+++ b/tests/validators/test_validators.py
@@ -1,9 +1,8 @@
+from cookieplone import validators
+from tui_forms.form.question import ValidationError
 from typing import Any
 
 import pytest
-from tui_forms.form.question import ValidationError
-
-from cookieplone import validators
 
 
 @pytest.mark.parametrize(

--- a/tests/wizard/conftest.py
+++ b/tests/wizard/conftest.py
@@ -1,12 +1,11 @@
 """Shared fixtures for wizard tests."""
 
+from cookieplone.config.state import CookieploneState
+from tui_forms.renderer.base import BaseRenderer
+from tui_forms.renderer.cookiecutter import CookiecutterRenderer
 from unittest.mock import MagicMock
 
 import pytest
-from tui_forms.renderer.base import BaseRenderer
-from tui_forms.renderer.cookiecutter import CookiecutterRenderer
-
-from cookieplone.config.state import CookieploneState
 
 
 @pytest.fixture()

--- a/tests/wizard/test_wizard.py
+++ b/tests/wizard/test_wizard.py
@@ -1,13 +1,13 @@
 """Tests for the wizard function."""
 
-from unittest.mock import MagicMock
-
-import pytest
-
 from cookieplone.config.state import Answers
 from cookieplone.exceptions import InvalidConfiguration
 from cookieplone.settings import RENDERER_VAR
-from cookieplone.wizard import _resolve_renderer, wizard
+from cookieplone.wizard import _resolve_renderer
+from cookieplone.wizard import wizard
+from unittest.mock import MagicMock
+
+import pytest
 
 
 def test_returns_answers(mock_create_form, mock_get_renderer, state):


### PR DESCRIPTION
## Summary

Adopts the same ruff isort configuration used across the rest of the Plone ecosystem (`plone/volto`, `plone/plone.restapi`, `kitconcept/*`, etc.) so contributors see consistent import style across the codebases they touch.

## Configuration

New section added to [`pyproject.toml`](pyproject.toml):

```toml
[tool.ruff.lint.isort]
case-sensitive = false
no-sections = true
force-single-line = true
from-first = true
lines-after-imports = 2
lines-between-types = 1
```

What each setting does:

| Setting | Effect |
|---|---|
| `case-sensitive = false` | Sort `Foo` and `foo` as equivalent. |
| `no-sections = true` | Collapse stdlib / third-party / first-party / local into a single block. |
| `force-single-line = true` | Each `from x import y, z` becomes two lines. |
| `from-first = true` | `from x import y` lines come **before** plain `import x` lines. |
| `lines-after-imports = 2` | Two blank lines between the import block and the first statement. |
| `lines-between-types = 1` | One blank line between `from` imports and `import` imports. |

## Reformat sweep

The entire codebase was reformatted in a single pass with `uvx ruff check --select I --fix .` followed by `uvx ruff format .`. **84 Python files** changed (335 insertions / 319 deletions). No runtime behavior changes — only import layout.

Sample (`cookieplone/wizard.py`):

```python
from cookieplone.config import Answers
from cookieplone.config import CookieploneState
from cookieplone.exceptions import InvalidConfiguration
from cookieplone.settings import DEFAULT_EXTENSIONS
from cookieplone.settings import DEFAULT_RENDERER
from cookieplone.settings import RENDERER_VAR
from tui_forms import available_renderers
from tui_forms import create_form
from tui_forms import get_renderer
from typing import Any

import os
```

## Verification

- `make lint` — all hooks pass
- `uv run pytest` — **856 passed**, 6 expected `DeprecationWarning`s
- `make docs-test` — 0 errors

## Closes

Closes #171