### PR TITLE
Add .git-blame-ignore-revs for the isort reformat sweep

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# Revisions to ignore when running `git blame`.
+#
+# Configure your local git to use this file automatically:
+#
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Align ruff isort configuration with other Plone projects (#171, #172)
+86472e98f8cfe79a8df14378597ca5daf8687370

--- a/news/+git-blame-ignore-revs.internal
+++ b/news/+git-blame-ignore-revs.internal
@@ -1,0 +1,1 @@
+Added a `.git-blame-ignore-revs` file so the codebase-wide isort reformat (#171) can be skipped when running `git blame`. @ericof


### PR DESCRIPTION
## Summary

Adds a `.git-blame-ignore-revs` file so the codebase-wide isort reformat from #171 / #172 (commit `86472e98f8cfe79a8df14378597ca5daf8687370`) can be skipped when running `git blame`.

The file includes a comment explaining how to opt in locally:

```console
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

GitHub honours this file automatically in the web blame view, so blame links from the issue tracker and PR reviews will already point past the reformat commit without any further configuration.

## Files

- `.git-blame-ignore-revs` — new file with one entry plus a header comment.
- `news/+git-blame-ignore-revs.internal` — news fragment.

## Notes

This is a follow-up to #172 (the isort sweep). No code changes.