### PR TITLE
Add post-gen actions helper and propagate versions to subtemplates

### DIFF
--- a/cookieplone/_types.py
+++ b/cookieplone/_types.py
@@ -89,6 +89,7 @@ class GenerateConfig:
     skip_if_file_exists: bool = False
     keep_project_on_failure: bool = False
     dump_answers: bool = True
+    global_versions: dict[str, str] | None = None
 
     def to_run_config(self) -> RunConfig:
         """Build a :class:`RunConfig` from this generation configuration."""

--- a/cookieplone/generator/__init__.py
+++ b/cookieplone/generator/__init__.py
@@ -97,12 +97,20 @@ def generate(config: GenerateConfig) -> Path:
     )
 
     # Define cookieplone state
+    # When the caller supplies explicit global_versions (e.g. a parent
+    # template propagating versions to a subtemplate), use them as the
+    # base layer.  Versions discovered from the repository config are
+    # merged on top so that repository-level overrides still take effect.
+    effective_versions = {
+        **(config.global_versions or {}),
+        **repository_info.global_versions,
+    }
     state: CookieploneState = generate_state(
         template_path=repo_dir,
         default_context=repository_info.config_dict["default_context"],
         extra_context=config.extra_context,
         replay_context=context_from_replayfile if config.replay else None,
-        global_versions=repository_info.global_versions,
+        global_versions=effective_versions,
     )
 
     run_config = config.to_run_config()
@@ -141,6 +149,7 @@ def generate_subtemplate(
     folder_name: str,
     context: OrderedDict,
     remove_files: list[str] | None = None,
+    global_versions: dict[str, str] | None = None,
 ) -> Path:
     """Generate a sub-template as part of a larger cookieplone run.
 
@@ -162,6 +171,10 @@ def generate_subtemplate(
         repository root and to pass answers through to the sub-template.
     :param remove_files: Optional list of paths relative to the generated
         folder that should be deleted after generation.
+    :param global_versions: Version pins from the parent template's
+        ``cookieplone-config.json``.  Passed through to the child
+        :func:`generate` call so that ``{{ versions.X }}`` works in child
+        template files.
     :returns: Path to the generated sub-template directory.
     :raises GeneratorException: If generation of the sub-template fails.
     """
@@ -194,6 +207,7 @@ def generate_subtemplate(
         overwrite_if_exists=True,
         template_path=template_path,
         dump_answers=False,
+        global_versions=global_versions,
     )
     with quiet_mode():
         result = generate(config)

--- a/cookieplone/utils/post_gen.py
+++ b/cookieplone/utils/post_gen.py
@@ -1,0 +1,194 @@
+"""Helpers for post-generation action hooks.
+
+Provides :func:`run_post_gen_actions` — a single dispatcher that replaces
+the boilerplate ``run_actions()`` loop duplicated across every template's
+``post_gen_project.py`` — together with a set of ready-made handlers for
+common post-generation tasks (git init, file removal, file moves, namespace
+packages, ``make format``).
+"""
+
+from collections import OrderedDict
+from collections.abc import Callable
+from cookieplone.utils.console import print as console_print
+from cookieplone.utils.files import remove_files
+from cookieplone.utils.git import initialize_repository
+from cookieplone.utils.plone import (
+    create_namespace_packages as _create_namespace_packages,
+)
+from copy import deepcopy
+from pathlib import Path
+from typing import TypedDict
+
+import logging
+import subprocess
+
+
+logger = logging.getLogger(__name__)
+
+#: Signature for post-generation action handlers.
+#: Receives ``(context, output_dir)`` and returns nothing.
+PostGenHandler = Callable[[OrderedDict, Path], None]
+
+
+class PostGenAction(TypedDict):
+    """A single post-generation action entry."""
+
+    handler: PostGenHandler
+    title: str
+    enabled: bool
+
+
+def run_post_gen_actions(
+    context: OrderedDict,
+    output_dir: Path,
+    actions: list[PostGenAction],
+) -> None:
+    """Run a list of post-generation actions against a generated project.
+
+    Each action is a :class:`PostGenAction` dict with *handler*, *title*,
+    and *enabled* keys.  Disabled actions are logged and skipped; enabled
+    actions receive a deep copy of *context* and the *output_dir*.
+
+    :param context: The cookiecutter context ``OrderedDict`` from the
+        post-generation hook.
+    :param output_dir: The generated project directory.
+    :param actions: Ordered list of actions to execute.
+    """
+    for action in actions:
+        title = action["title"]
+        enabled = action["enabled"]
+        handler = action["handler"]
+
+        if not int(enabled):
+            console_print(f" -> Ignoring ({title})")
+            continue
+
+        console_print(f" -> {title}")
+        handler(deepcopy(context), output_dir)
+
+
+# ---------------------------------------------------------------------------
+# Built-in handlers
+# ---------------------------------------------------------------------------
+
+
+def initialize_git_repository(context: OrderedDict, output_dir: Path) -> None:
+    """Initialize a git repository in *output_dir* and stage all files.
+
+    Wraps :func:`~cookieplone.utils.git.initialize_repository`.  After the
+    initial ``git add`` performed by that function, a second ``git add`` is
+    run to capture any files created by earlier post-gen actions.
+    """
+    repo = initialize_repository(output_dir)
+    repo.git.add(output_dir)
+
+
+def create_namespace_packages(context: OrderedDict, output_dir: Path) -> None:
+    """Create Python namespace package structure.
+
+    Reads ``python_package_name`` from *context* and delegates to
+    :func:`~cookieplone.utils.plone.create_namespace_packages`.  The
+    ``namespace_style`` key defaults to ``"native"`` (PEP 420).
+    """
+    package_name = context.get("python_package_name", "")
+    if not package_name or "." not in package_name:
+        return
+    style = context.get("namespace_style", "native")
+    _create_namespace_packages(output_dir, package_name, style)
+
+
+def remove_files_by_key(
+    to_remove: dict[str, list[str]],
+    key: str,
+) -> PostGenHandler:
+    """Return a handler that removes files listed under *key* in *to_remove*.
+
+    :param to_remove: Mapping of group keys to lists of relative paths.
+    :param key: The group to remove.
+    :returns: A :data:`PostGenHandler` suitable for :class:`PostGenAction`.
+
+    Example::
+
+        POST_GEN_TO_REMOVE = {
+            "devops-ansible": ["devops/ansible"],
+            "devops-gha": [".github/workflows/deploy.yml"],
+        }
+        action = {
+            "handler": remove_files_by_key(POST_GEN_TO_REMOVE, "devops-ansible"),
+            "title": "Remove Ansible files",
+            "enabled": True,
+        }
+    """
+
+    def _handler(context: OrderedDict, output_dir: Path) -> None:
+        paths = to_remove.get(key, [])
+        if paths:
+            remove_files(output_dir, paths)
+
+    return _handler
+
+
+def move_files(
+    pairs: list[tuple[str, str]],
+) -> PostGenHandler:
+    """Return a handler that renames files within *output_dir*.
+
+    :param pairs: List of ``(source, destination)`` relative paths.
+    :returns: A :data:`PostGenHandler` suitable for :class:`PostGenAction`.
+
+    Example::
+
+        action = {
+            "handler": move_files([("docs/.readthedocs.yaml", ".readthedocs.yml")]),
+            "title": "Move docs config",
+            "enabled": True,
+        }
+    """
+
+    def _handler(context: OrderedDict, output_dir: Path) -> None:
+        for src, dst in pairs:
+            src_path = output_dir / src
+            dst_path = output_dir / dst
+            if src_path.exists():
+                dst_path.parent.mkdir(parents=True, exist_ok=True)
+                src_path.rename(dst_path)
+            else:
+                logger.warning(
+                    f"move_files: source {src_path} does not exist, skipping"
+                )
+
+    return _handler
+
+
+def run_make_format(
+    make_target: str = "format",
+    folder: str = "",
+) -> PostGenHandler:
+    """Return a handler that runs ``make <target>`` in a subfolder.
+
+    :param make_target: The make target to invoke (default ``"format"``).
+    :param folder: Subfolder relative to *output_dir*.  When empty, runs
+        in *output_dir* itself.
+    :returns: A :data:`PostGenHandler` suitable for :class:`PostGenAction`.
+
+    Example::
+
+        action = {
+            "handler": run_make_format("format", "backend"),
+            "title": "Format backend code",
+            "enabled": True,
+        }
+    """
+
+    def _handler(context: OrderedDict, output_dir: Path) -> None:
+        cwd = output_dir / folder if folder else output_dir
+        if not (cwd / "Makefile").exists():
+            logger.warning(f"run_make_format: no Makefile in {cwd}, skipping")
+            return
+        subprocess.run(  # noqa: S603
+            ["make", make_target],  # noqa: S607
+            cwd=cwd,
+            capture_output=True,
+        )
+
+    return _handler

--- a/cookieplone/utils/subtemplates.py
+++ b/cookieplone/utils/subtemplates.py
@@ -78,6 +78,7 @@ def run_subtemplates(
     context: OrderedDict,
     output_dir: Path,
     handlers: dict[str, SubtemplateHandler] | None = None,
+    global_versions: dict[str, str] | None = None,
 ) -> dict[str, Path]:
     """Process and generate all subtemplates defined in the context.
 
@@ -101,6 +102,10 @@ def run_subtemplates(
     :param handlers: Optional mapping of ``template_id`` →
         :data:`SubtemplateHandler` for subtemplates that need custom
         context manipulation.
+    :param global_versions: Version pins from the parent template's
+        ``cookieplone-config.json``.  Forwarded to each
+        :func:`~cookieplone.generator.generate_subtemplate` call so
+        that ``{{ versions.X }}`` works in child template files.
     :returns: Dict mapping ``template_id`` → generated ``Path`` for
         each subtemplate that was processed.
     """
@@ -151,6 +156,7 @@ def run_subtemplates(
                     output_dir=gen_output_dir,
                     folder_name=gen_folder_name,
                     context=deepcopy(context),
+                    global_versions=global_versions,
                 )
 
         results[template_id] = path

--- a/docs/src/how-to-guides/call-subtemplates-from-a-hook.md
+++ b/docs/src/how-to-guides/call-subtemplates-from-a-hook.md
@@ -177,7 +177,12 @@ def main():
     output_dir = Path.cwd()
 
     # {{ cookiecutter.__cookieplone_subtemplates }}
-    run_subtemplates(context, output_dir, handlers=SUBTEMPLATE_HANDLERS)
+    run_subtemplates(
+        context,
+        output_dir,
+        handlers=SUBTEMPLATE_HANDLERS,
+        global_versions=versions,
+    )
 
     # Continue with other post-generation tasks (namespace packages,
     # code formatting, git initialization, ...).
@@ -190,6 +195,33 @@ def main():
 
 if __name__ == "__main__":
     main()
+```
+
+### Propagating version pins
+
+The `global_versions` parameter passes the parent template's version pins (from {ref}`config.versions <repo-config>`) to each child sub-template.
+Without it, child templates cannot use `{{ versions.X }}` expressions because the `versions` dict would be empty when the sub-template renders.
+
+Pass the `versions` variable that Cookiecutter renders from the repository's `cookieplone-config.json`:
+
+```python
+versions: dict | OrderedDict = {{versions}}
+
+# later, in main():
+run_subtemplates(context, output_dir, handlers=SUBTEMPLATE_HANDLERS, global_versions=versions)
+```
+
+If your handlers call {py:func}`cookieplone.generator.generate_subtemplate` directly, pass `global_versions` there too:
+
+```python
+def generate_addons_backend(context: OrderedDict, output_dir: Path) -> Path:
+    return generator.generate_subtemplate(
+        f"{TEMPLATES_FOLDER}/add-ons/backend",
+        output_dir,
+        "backend",
+        context,
+        global_versions=versions,
+    )
 ```
 
 The trailing `# {{ cookiecutter.__cookieplone_subtemplates }}` comment is **important**: it ensures Cookiecutter treats the sub-templates list as a rendered context value, which is what `run_subtemplates()` then reads at runtime.

--- a/docs/src/how-to-guides/index.md
+++ b/docs/src/how-to-guides/index.md
@@ -37,6 +37,7 @@ add-computed-fields
 use-built-in-filters
 create-a-hidden-template
 call-subtemplates-from-a-hook
+run-post-gen-actions
 write-a-pre-prompt-hook
 ```
 

--- a/docs/src/how-to-guides/run-post-gen-actions.md
+++ b/docs/src/how-to-guides/run-post-gen-actions.md
@@ -1,0 +1,202 @@
+---
+myst:
+  html_meta:
+    "description": "How to use run_post_gen_actions() and built-in handlers to streamline post-generation hooks."
+    "property=og:description": "How to use run_post_gen_actions() and built-in handlers to streamline post-generation hooks."
+    "property=og:title": "Run post-generation actions"
+    "keywords": "Cookieplone, post_gen_project, run_post_gen_actions, handlers, git, namespace packages"
+---
+
+# Run post-generation actions
+
+This guide shows how to replace hand-rolled action loops in `post_gen_project.py` with {py:func}`cookieplone.utils.post_gen.run_post_gen_actions` and its built-in handlers.
+
+## The problem
+
+Every template's post-generation hook tends to repeat the same pattern:
+
+```python
+# Old pattern, duplicated across templates.
+actions = [
+    [handle_backend_cleanup, "Backend final cleanup", True],
+    [handle_devops_ansible, "Remove Ansible files", not feature_devops_ansible],
+    [handle_git_initialization, "Initialize Git repository", initialize_git],
+]
+for func, title, enabled in actions:
+    if not int(enabled):
+        continue
+    console.print(f" -> {title}")
+    func(deepcopy(context), output_dir)
+```
+
+`run_post_gen_actions()` replaces this boilerplate with a single call and ships ready-made handlers for the most common tasks.
+
+## Prerequisites
+
+- Your template has a `hooks/post_gen_project.py` file.
+- You have already handled sub-template generation (see {doc}`call-subtemplates-from-a-hook`) and now want to run final cleanup actions.
+
+## Step 1: Import the helper and handlers
+
+```python
+from collections import OrderedDict
+from pathlib import Path
+
+from cookieplone.utils.post_gen import (
+    run_post_gen_actions,
+    create_namespace_packages,
+    initialize_git_repository,
+    move_files,
+    remove_files_by_key,
+    run_make_format,
+)
+
+context: OrderedDict = {{cookiecutter}}
+```
+
+## Step 2: Define your action list
+
+Each action is a dictionary with three keys:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `handler` | `Callable[[OrderedDict, Path], None]` | The function to run. |
+| `title` | `str` | Label printed to the console. |
+| `enabled` | `bool` | When false (or `0`), the action is skipped with an "Ignoring" message. |
+
+```python
+POST_GEN_TO_REMOVE = {
+    "devops-ansible": ["devops/ansible"],
+    "devops-gha": [".github/workflows/deploy.yml"],
+}
+
+initialize_git = context.get("initialize_git", "1")
+
+actions = [
+    {
+        "handler": create_namespace_packages,
+        "title": "Backend final cleanup",
+        "enabled": True,
+    },
+    {
+        "handler": remove_files_by_key(POST_GEN_TO_REMOVE, "devops-ansible"),
+        "title": "Remove Ansible files",
+        "enabled": not int(context.get("feature_devops_ansible", "0")),
+    },
+    {
+        "handler": move_files([("docs/.readthedocs.yaml", ".readthedocs.yml")]),
+        "title": "Organize documentation files",
+        "enabled": int(context.get("feature_documentation", "0")),
+    },
+    {
+        "handler": run_make_format("format", "backend"),
+        "title": "Format backend code",
+        "enabled": True,
+    },
+    {
+        "handler": initialize_git_repository,
+        "title": "Initialize Git repository",
+        "enabled": initialize_git,
+    },
+]
+```
+
+## Step 3: Invoke from `main()`
+
+```python
+def main():
+    output_dir = Path.cwd()
+
+    # Sub-template generation (if any) goes here first.
+    # ...
+
+    # Post-generation actions
+    run_post_gen_actions(context, output_dir, actions)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+Each enabled action receives a **deep copy** of the context, so handlers can safely mutate it without affecting subsequent actions.
+
+## Built-in handlers
+
+### `initialize_git_repository`
+
+Initializes a git repository in the output directory and stages all files.
+Wraps {py:func}`cookieplone.utils.git.initialize_repository` with a second `git add` to capture files created by earlier actions.
+
+```python
+{"handler": initialize_git_repository, "title": "Initialize Git", "enabled": True}
+```
+
+### `create_namespace_packages`
+
+Creates Python namespace package directories.
+Reads `python_package_name` and `namespace_style` (default `"native"`) from the context.
+Skips if the package name has no dots.
+
+```python
+{"handler": create_namespace_packages, "title": "Namespace packages", "enabled": True}
+```
+
+### `remove_files_by_key(to_remove, key)`
+
+Factory that returns a handler removing files listed under the given key in the removal dict.
+
+```python
+TO_REMOVE = {
+    "devops-ansible": ["devops/ansible", "devops/ansible.cfg"],
+    "devops-gha": [".github/workflows/deploy.yml"],
+}
+{"handler": remove_files_by_key(TO_REMOVE, "devops-ansible"), "title": "Remove Ansible", "enabled": True}
+```
+
+### `move_files(pairs)`
+
+Factory that returns a handler renaming files within the output directory.
+Creates destination parent directories as needed.
+
+```python
+{"handler": move_files([("docs/.readthedocs.yaml", ".readthedocs.yml")]), "title": "Move docs", "enabled": True}
+```
+
+### `run_make_format(make_target, folder)`
+
+Factory that returns a handler running `make <target>` in a subfolder.
+Defaults to `make format` in the output directory.
+Skips silently if no `Makefile` is found.
+
+```python
+{"handler": run_make_format("format", "backend"), "title": "Format backend", "enabled": True}
+```
+
+## Writing custom handlers
+
+Any function matching the `PostGenHandler` signature works:
+
+```python
+from collections import OrderedDict
+from pathlib import Path
+
+
+def my_custom_action(context: OrderedDict, output_dir: Path) -> None:
+    """Do something template-specific."""
+    config_path = output_dir / "config.yaml"
+    if config_path.exists():
+        # Template-specific logic here
+        ...
+```
+
+Then use it in the actions list:
+
+```python
+{"handler": my_custom_action, "title": "Custom config setup", "enabled": True}
+```
+
+## Related pages
+
+- {doc}`call-subtemplates-from-a-hook`: orchestrating sub-template generation before post-gen actions.
+- {doc}`write-a-pre-prompt-hook`: running validation *before* the wizard.
+- {doc}`/concepts/how-cookieplone-works`: the full generation pipeline.

--- a/news/177.feature
+++ b/news/177.feature
@@ -1,0 +1,1 @@
+Added `run_post_gen_actions()` helper and built-in post-generation handlers (`initialize_git_repository`, `create_namespace_packages`, `remove_files_by_key`, `move_files`, `run_make_format`) in `cookieplone.utils.post_gen`. @ericof

--- a/news/178.bugfix
+++ b/news/178.bugfix
@@ -1,0 +1,1 @@
+Propagated versions dict to child templates in `generate_subtemplate()` and `run_subtemplates()` via explicit `global_versions` parameter, fixing `{{ versions.X }}` in subtemplates. @ericof

--- a/tests/generator/test_generate.py
+++ b/tests/generator/test_generate.py
@@ -42,3 +42,40 @@ def test_preflight_exception_reraised(mock_get_repository, generate_config):
     config = replace(generate_config, no_input=False)
     with pytest.raises(PreFlightException):
         generate(config)
+
+
+def test_merges_config_and_repo_global_versions(
+    mock_get_repository,
+    mock_load_replay,
+    mock_generate_state,
+    mock_cookieplone_entry,
+    mock_dump_replay,
+    mock_write_answers,
+    repository_info_with_config,
+    generate_config,
+    tmp_path,
+):
+    """generate merges config.global_versions with repo-discovered versions."""
+    # Repo-discovered versions (from cookieplone-config.json)
+    repo_versions = {"plone.api": "2.1.0", "volto": "18.0.0"}
+    repository_info_with_config.global_versions = repo_versions
+    mock_get_repository.return_value = repository_info_with_config
+    mock_cookieplone_entry.return_value = tmp_path / "output"
+
+    # Caller-provided versions (from parent template)
+    caller_versions = {"plone.api": "2.0.0", "plone.restapi": "9.0.0"}
+    config = replace(generate_config, no_input=False, global_versions=caller_versions)
+
+    generate(config)
+
+    # generate_state should receive merged versions:
+    # caller as base, repo overrides
+    call_kwargs = mock_generate_state.call_args
+    effective = call_kwargs.kwargs.get("global_versions") or call_kwargs[1].get(
+        "global_versions"
+    )
+    assert effective == {
+        "plone.api": "2.1.0",  # repo overrides caller
+        "plone.restapi": "9.0.0",  # caller-only key preserved
+        "volto": "18.0.0",  # repo-only key preserved
+    }

--- a/tests/generator/test_generate_subtemplate.py
+++ b/tests/generator/test_generate_subtemplate.py
@@ -208,3 +208,51 @@ def test_does_not_warn_when_in_quiet_mode(
         w for w in captured if issubclass(w.category, DeprecationWarning)
     ]
     assert deprecation_warnings == []
+
+
+def test_propagates_global_versions(
+    mock_remove_internal_keys,
+    mock_get_repository_root,
+    mock_quiet_mode,
+    mock_generate,
+    tmp_path,
+):
+    """generate_subtemplate passes global_versions to GenerateConfig."""
+    mock_remove_internal_keys.return_value = {"title": "Test"}
+    mock_get_repository_root.return_value = str(tmp_path / "repo")
+    mock_generate.return_value = tmp_path / "output"
+    context = OrderedDict({"title": "Test", "_template": "/some/path"})
+    versions = {"plone.api": "2.1.0", "plone.restapi": "9.0.0"}
+
+    generate_subtemplate(
+        template_path="sub",
+        output_dir=tmp_path,
+        folder_name="my_folder",
+        context=context,
+        global_versions=versions,
+    )
+    config = mock_generate.call_args[0][0]
+    assert config.global_versions == versions
+
+
+def test_global_versions_defaults_to_none(
+    mock_remove_internal_keys,
+    mock_get_repository_root,
+    mock_quiet_mode,
+    mock_generate,
+    tmp_path,
+):
+    """generate_subtemplate defaults global_versions to None."""
+    mock_remove_internal_keys.return_value = {"title": "Test"}
+    mock_get_repository_root.return_value = str(tmp_path / "repo")
+    mock_generate.return_value = tmp_path / "output"
+    context = OrderedDict({"title": "Test", "_template": "/some/path"})
+
+    generate_subtemplate(
+        template_path="sub",
+        output_dir=tmp_path,
+        folder_name="my_folder",
+        context=context,
+    )
+    config = mock_generate.call_args[0][0]
+    assert config.global_versions is None

--- a/tests/utils/test_post_gen.py
+++ b/tests/utils/test_post_gen.py
@@ -1,0 +1,280 @@
+"""Tests for cookieplone.utils.post_gen."""
+
+from collections import OrderedDict
+from cookieplone.utils.post_gen import PostGenAction
+from cookieplone.utils.post_gen import create_namespace_packages
+from cookieplone.utils.post_gen import initialize_git_repository
+from cookieplone.utils.post_gen import move_files
+from cookieplone.utils.post_gen import remove_files_by_key
+from cookieplone.utils.post_gen import run_make_format
+from cookieplone.utils.post_gen import run_post_gen_actions
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def context():
+    """A minimal cookiecutter context."""
+    return OrderedDict({"title": "My Project", "python_package_name": "my.addon"})
+
+
+@pytest.fixture
+def output_dir(tmp_path):
+    """A temporary output directory."""
+    project = tmp_path / "my-project"
+    project.mkdir()
+    return project
+
+
+class TestRunPostGenActions:
+    """Tests for run_post_gen_actions."""
+
+    @patch("cookieplone.utils.post_gen.console_print")
+    def test_empty_actions(self, mock_print, context, output_dir):
+        """No-op when actions list is empty."""
+        run_post_gen_actions(context, output_dir, [])
+        mock_print.assert_not_called()
+
+    @patch("cookieplone.utils.post_gen.console_print")
+    def test_disabled_action_skipped(self, mock_print, context, output_dir):
+        """Disabled actions are skipped with an Ignoring message."""
+        handler = MagicMock()
+        actions: list[PostGenAction] = [
+            {"handler": handler, "title": "Skip me", "enabled": False},
+        ]
+        run_post_gen_actions(context, output_dir, actions)
+        handler.assert_not_called()
+        mock_print.assert_called_once_with(" -> Ignoring (Skip me)")
+
+    @patch("cookieplone.utils.post_gen.console_print")
+    def test_enabled_action_called(self, mock_print, context, output_dir):
+        """Enabled actions are called with deep-copied context and output_dir."""
+        handler = MagicMock()
+        actions: list[PostGenAction] = [
+            {"handler": handler, "title": "Do stuff", "enabled": True},
+        ]
+        run_post_gen_actions(context, output_dir, actions)
+        handler.assert_called_once()
+        call_args = handler.call_args[0]
+        # Receives a deep copy, not the original
+        assert call_args[0] is not context
+        assert call_args[0] == context
+        assert call_args[1] == output_dir
+        mock_print.assert_called_once_with(" -> Do stuff")
+
+    @patch("cookieplone.utils.post_gen.console_print")
+    def test_mixed_enabled_disabled(self, mock_print, context, output_dir):
+        """Mix of enabled and disabled actions."""
+        h1 = MagicMock()
+        h2 = MagicMock()
+        h3 = MagicMock()
+        actions: list[PostGenAction] = [
+            {"handler": h1, "title": "First", "enabled": True},
+            {"handler": h2, "title": "Second", "enabled": False},
+            {"handler": h3, "title": "Third", "enabled": True},
+        ]
+        run_post_gen_actions(context, output_dir, actions)
+        h1.assert_called_once()
+        h2.assert_not_called()
+        h3.assert_called_once()
+
+    @patch("cookieplone.utils.post_gen.console_print")
+    def test_int_coercible_enabled(self, mock_print, context, output_dir):
+        """Enabled value is coerced via int() — '0' is falsy, '1' is truthy."""
+        handler = MagicMock()
+        actions: list[PostGenAction] = [
+            {"handler": handler, "title": "Coerced", "enabled": "1"},
+        ]
+        run_post_gen_actions(context, output_dir, actions)
+        handler.assert_called_once()
+
+    @patch("cookieplone.utils.post_gen.console_print")
+    def test_preserves_execution_order(self, mock_print, context, output_dir):
+        """Actions execute in list order."""
+        calls = []
+        for i in range(3):
+            h = MagicMock(side_effect=lambda *a, idx=i: calls.append(idx))
+            actions = [{"handler": h, "title": f"Step {i}", "enabled": True}]
+            run_post_gen_actions(context, output_dir, actions)
+        assert calls == [0, 1, 2]
+
+
+class TestInitializeGitRepository:
+    """Tests for initialize_git_repository handler."""
+
+    @patch("cookieplone.utils.post_gen.initialize_repository")
+    def test_calls_initialize_and_adds(self, mock_init, context, output_dir):
+        """Initializes repo and runs a second git add."""
+        mock_repo = MagicMock()
+        mock_init.return_value = mock_repo
+
+        initialize_git_repository(context, output_dir)
+
+        mock_init.assert_called_once_with(output_dir)
+        mock_repo.git.add.assert_called_once_with(output_dir)
+
+
+class TestCreateNamespacePackages:
+    """Tests for create_namespace_packages handler."""
+
+    @patch("cookieplone.utils.post_gen._create_namespace_packages")
+    def test_calls_with_package_name(self, mock_create, output_dir):
+        """Delegates to plone.create_namespace_packages with context values."""
+        ctx = OrderedDict({"python_package_name": "plone.app.testing"})
+        create_namespace_packages(ctx, output_dir)
+        mock_create.assert_called_once_with(output_dir, "plone.app.testing", "native")
+
+    @patch("cookieplone.utils.post_gen._create_namespace_packages")
+    def test_respects_namespace_style(self, mock_create, output_dir):
+        """Uses namespace_style from context when present."""
+        ctx = OrderedDict({
+            "python_package_name": "plone.app.testing",
+            "namespace_style": "pkgutil",
+        })
+        create_namespace_packages(ctx, output_dir)
+        mock_create.assert_called_once_with(output_dir, "plone.app.testing", "pkgutil")
+
+    @patch("cookieplone.utils.post_gen._create_namespace_packages")
+    def test_skips_non_namespaced(self, mock_create, output_dir):
+        """Skips when package_name has no dots."""
+        ctx = OrderedDict({"python_package_name": "myaddon"})
+        create_namespace_packages(ctx, output_dir)
+        mock_create.assert_not_called()
+
+    @patch("cookieplone.utils.post_gen._create_namespace_packages")
+    def test_skips_empty_package_name(self, mock_create, output_dir):
+        """Skips when python_package_name is missing."""
+        ctx = OrderedDict({})
+        create_namespace_packages(ctx, output_dir)
+        mock_create.assert_not_called()
+
+
+class TestRemoveFilesByKey:
+    """Tests for remove_files_by_key factory."""
+
+    def test_returns_callable(self):
+        """Factory returns a PostGenHandler."""
+        handler = remove_files_by_key({"k": ["a.txt"]}, "k")
+        assert callable(handler)
+
+    @patch("cookieplone.utils.post_gen.remove_files")
+    def test_removes_matching_files(self, mock_remove, context, output_dir):
+        """Handler removes files listed under the given key."""
+        to_remove = {"devops-ansible": ["devops/ansible", "devops/vars"]}
+        handler = remove_files_by_key(to_remove, "devops-ansible")
+        handler(context, output_dir)
+        mock_remove.assert_called_once_with(
+            output_dir, ["devops/ansible", "devops/vars"]
+        )
+
+    @patch("cookieplone.utils.post_gen.remove_files")
+    def test_missing_key_is_noop(self, mock_remove, context, output_dir):
+        """Handler is a no-op when key is not in the dict."""
+        handler = remove_files_by_key({"other": ["x"]}, "missing")
+        handler(context, output_dir)
+        mock_remove.assert_not_called()
+
+
+class TestMoveFiles:
+    """Tests for move_files factory."""
+
+    def test_returns_callable(self):
+        """Factory returns a PostGenHandler."""
+        handler = move_files([("a", "b")])
+        assert callable(handler)
+
+    def test_renames_files(self, context, output_dir):
+        """Handler renames source to destination."""
+        src = output_dir / "docs" / ".readthedocs.yaml"
+        src.parent.mkdir(parents=True)
+        src.write_text("config")
+
+        handler = move_files([("docs/.readthedocs.yaml", ".readthedocs.yml")])
+        handler(context, output_dir)
+
+        assert not src.exists()
+        assert (output_dir / ".readthedocs.yml").read_text() == "config"
+
+    def test_creates_parent_dirs(self, context, output_dir):
+        """Handler creates destination parent directories."""
+        src = output_dir / "flat.txt"
+        src.write_text("data")
+
+        handler = move_files([("flat.txt", "deep/nested/flat.txt")])
+        handler(context, output_dir)
+
+        assert not src.exists()
+        assert (output_dir / "deep" / "nested" / "flat.txt").read_text() == "data"
+
+    def test_missing_source_skipped(self, context, output_dir):
+        """Handler skips pairs where source does not exist."""
+        handler = move_files([("nonexistent.txt", "dest.txt")])
+        handler(context, output_dir)  # Should not raise
+        assert not (output_dir / "dest.txt").exists()
+
+    def test_multiple_pairs(self, context, output_dir):
+        """Handler processes multiple pairs in order."""
+        (output_dir / "a.txt").write_text("A")
+        (output_dir / "b.txt").write_text("B")
+
+        handler = move_files([("a.txt", "moved_a.txt"), ("b.txt", "moved_b.txt")])
+        handler(context, output_dir)
+
+        assert (output_dir / "moved_a.txt").read_text() == "A"
+        assert (output_dir / "moved_b.txt").read_text() == "B"
+
+
+class TestRunMakeFormat:
+    """Tests for run_make_format factory."""
+
+    def test_returns_callable(self):
+        """Factory returns a PostGenHandler."""
+        handler = run_make_format()
+        assert callable(handler)
+
+    @patch("cookieplone.utils.post_gen.subprocess.run")
+    def test_runs_make_in_output_dir(self, mock_run, context, output_dir):
+        """Handler runs make in output_dir when no folder specified."""
+        (output_dir / "Makefile").write_text("format:\n\techo ok")
+        handler = run_make_format()
+        handler(context, output_dir)
+        mock_run.assert_called_once_with(
+            ["make", "format"],
+            cwd=output_dir,
+            capture_output=True,
+        )
+
+    @patch("cookieplone.utils.post_gen.subprocess.run")
+    def test_runs_make_in_subfolder(self, mock_run, context, output_dir):
+        """Handler runs make in the specified subfolder."""
+        backend = output_dir / "backend"
+        backend.mkdir()
+        (backend / "Makefile").write_text("format:\n\techo ok")
+        handler = run_make_format("format", "backend")
+        handler(context, output_dir)
+        mock_run.assert_called_once_with(
+            ["make", "format"],
+            cwd=backend,
+            capture_output=True,
+        )
+
+    @patch("cookieplone.utils.post_gen.subprocess.run")
+    def test_custom_target(self, mock_run, context, output_dir):
+        """Handler respects custom make target."""
+        (output_dir / "Makefile").write_text("lint:\n\techo ok")
+        handler = run_make_format("lint")
+        handler(context, output_dir)
+        mock_run.assert_called_once_with(
+            ["make", "lint"],
+            cwd=output_dir,
+            capture_output=True,
+        )
+
+    @patch("cookieplone.utils.post_gen.subprocess.run")
+    def test_no_makefile_skips(self, mock_run, context, output_dir):
+        """Handler is a no-op when Makefile is missing."""
+        handler = run_make_format()
+        handler(context, output_dir)
+        mock_run.assert_not_called()

--- a/tests/utils/test_subtemplates.py
+++ b/tests/utils/test_subtemplates.py
@@ -463,3 +463,42 @@ class TestRunSubtemplates:
         ]
         run_subtemplates(context, output_dir, handlers={"add-ons/backend": handler})
         assert QUIET_MODE_VAR not in os.environ
+
+    @patch("cookieplone.generator.generate_subtemplate")
+    @patch("cookieplone.utils.subtemplates.console_print")
+    def test_forwards_global_versions(
+        self, mock_print, mock_generate, context, output_dir
+    ):
+        """global_versions is forwarded to generate_subtemplate calls."""
+        mock_generate.return_value = output_dir / "backend"
+        context["__cookieplone_subtemplates"] = [
+            {
+                "id": "add-ons/backend",
+                "title": "Backend",
+                "enabled": "1",
+                "folder_name": "backend",
+            },
+        ]
+        versions = {"plone.api": "2.1.0", "plone.restapi": "9.0.0"}
+        run_subtemplates(context, output_dir, global_versions=versions)
+        call_kwargs = mock_generate.call_args
+        assert call_kwargs.kwargs["global_versions"] == versions
+
+    @patch("cookieplone.generator.generate_subtemplate")
+    @patch("cookieplone.utils.subtemplates.console_print")
+    def test_global_versions_defaults_to_none(
+        self, mock_print, mock_generate, context, output_dir
+    ):
+        """global_versions defaults to None when not provided."""
+        mock_generate.return_value = output_dir / "backend"
+        context["__cookieplone_subtemplates"] = [
+            {
+                "id": "add-ons/backend",
+                "title": "Backend",
+                "enabled": "1",
+                "folder_name": "backend",
+            },
+        ]
+        run_subtemplates(context, output_dir)
+        call_kwargs = mock_generate.call_args
+        assert call_kwargs.kwargs["global_versions"] is None


### PR DESCRIPTION
## Summary

- **#178 (bugfix):** `generate_subtemplate()` and `run_subtemplates()` now accept an explicit `global_versions` parameter, propagating version pins from `cookieplone-config.json` to child templates so that `{{ versions.X }}` works in subtemplates. `GenerateConfig` gains a `global_versions` field, and `generate()` merges caller-provided versions with repo-discovered ones.

- **#177 (feature):** New `cookieplone.utils.post_gen` module with `run_post_gen_actions()` dispatcher and five built-in handlers: `initialize_git_repository`, `create_namespace_packages`, `remove_files_by_key`, `move_files`, `run_make_format`. This eliminates the ~15-line `run_actions()` boilerplate duplicated across every template's `post_gen_project.py`.

Closes #177
Closes #178

## Test plan

- [x] `pytest` passes (885 tests, 29 new across both issues)
- [x] `ruff check` and `ruff format` clean
- [x] Pre-commit hooks pass on both commits
- [x] Verify `run_post_gen_actions()` API matches the usage pattern described in #177
- [x] Verify `global_versions` propagation merges correctly (caller as base, repo overrides)