### PR TITLE
Move min_version check earlier and refactor console screens

### DIFF
--- a/cookieplone/cli/__init__.py
+++ b/cookieplone/cli/__init__.py
@@ -263,7 +263,11 @@ def cli(
     if answers_data := parse_answers_file(answers_file):
         template = answers_data.pop("__template__", template)
 
-    repo_path = get_base_repository(repository, tag)
+    try:
+        repo_path = get_base_repository(repository, tag)
+    except VersionTooOldException as exc:
+        console.sanity_screen(exc.message)
+        raise typer.Exit(1) from exc
 
     # Template info
     cookieplone_template = get_template(template, repo_path, all_)

--- a/cookieplone/repository.py
+++ b/cookieplone/repository.py
@@ -67,6 +67,9 @@ def get_base_repository(
         directory="",
     )
     base_repo_dir = Path(base_repo_dir).resolve()
+    if _repository_has_config(base_repo_dir):
+        repo_config = get_repository_config(base_repo_dir)
+        _check_min_version(repo_config.get("config", {}))
     return base_repo_dir
 
 
@@ -376,7 +379,7 @@ def _check_min_version(config_section: dict[str, Any]) -> None:
     required = Version(min_version_str)
     if installed < required:
         msg = (
-            f"This template requires cookieplone >= {required}, "
+            f"This repository requires cookieplone >= {required}, "
             f"but you have {installed} installed.\n"
             f"Please upgrade:  uvx --no-cache cookieplone@{required}"
         )

--- a/cookieplone/settings.py
+++ b/cookieplone/settings.py
@@ -136,3 +136,8 @@ DEFAULT_EXTENSIONS = [
     "cookiecutter.extensions.TimeExtension",
     "cookiecutter.extensions.UUIDExtension",
 ]
+
+SIGNATURE = (
+    "Made with [bold][red]❤️[/red][/bold] by the"
+    " [bold][blue]Plone Community[/blue][/bold]"
+)

--- a/cookieplone/utils/console.py
+++ b/cookieplone/utils/console.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from contextlib import contextmanager
 from cookieplone import __version__ as cookieplone_version
 from cookieplone import _types as t
-from cookieplone.settings import QUIET_MODE_VAR
+from cookieplone import settings
 from pathlib import Path
 from rich import print as base_print
 from rich.align import Align
@@ -79,7 +79,7 @@ def choose_banner() -> str:
 
 def _print(msg: str):
     """Wrapper around rich.print."""
-    if not os.environ.get(QUIET_MODE_VAR):
+    if not os.environ.get(settings.QUIET_MODE_VAR):
         base_print(msg)
 
 
@@ -199,6 +199,47 @@ def list_available_groups(
     return styled_list(items)
 
 
+def _render_screen(items: Sequence[Panel | Align], display_banner: bool = True) -> None:
+    """Clear the terminal and render a branded cookieplone screen.
+
+    Wraps the provided *items* inside a titled :class:`~rich.panel.Panel`
+    with the cookieplone version header and community signature.  When
+    *display_banner* is ``True`` the Plone logo is prepended.
+
+    :param items: Rich renderables (typically :class:`~rich.panel.Panel`
+        instances) to display inside the outer chrome.
+    :param display_banner: When ``True`` (default) prepend the Plone ASCII
+        banner above *items*.
+    """
+    clear_screen()
+    if display_banner:
+        banner = choose_banner()
+        items = [Align.center(f"[bold blue]{banner}[/bold blue]"), *items]
+    panel_title = f"cookieplone ({cookieplone_version})"
+    panel = Panel(
+        Group(*items),
+        title=panel_title,
+        subtitle=settings.SIGNATURE,
+    )
+    base_print(panel)
+
+
+def sanity_screen(msg: str) -> None:
+    """Display a full-screen error panel with the Plone banner.
+
+    Used for fatal pre-flight errors (e.g. version gating) that should be
+    shown *instead of* the welcome screen.
+
+    :param msg: Plain-text error message.  Rich markup characters are escaped
+        automatically.
+    """
+    styled_msg = f"\n[red]{escape(msg)}[/red]\n"
+    items = [
+        Panel(styled_msg, title="Error", title_align="left"),
+    ]
+    _render_screen(items, display_banner=True)
+
+
 def welcome_screen(
     templates: dict[str, t.CookieploneTemplate] | None = None,
     groups: dict[str, t.CookieploneTemplateGroup] | None = None,
@@ -214,11 +255,7 @@ def welcome_screen(
     """
     # Always clear the screen, even if we're not printing the banner,
     # to ensure a clean start.
-    clear_screen()
-    banner = choose_banner()
-    items = [
-        Align.center(f"[bold blue]{banner}[/bold blue]"),
-    ]
+    items = []
     if groups:
         items.append(
             Panel(list_available_groups(groups), title="Categories", title_align="left")
@@ -231,12 +268,7 @@ def welcome_screen(
                 title_align="left",
             )
         )
-    panel_title = f"cookieplone ({cookieplone_version})"
-    panel = Panel(
-        Group(*items),
-        title=panel_title,
-    )
-    base_print(panel)
+    _render_screen(items, display_banner=True)
 
 
 def version_screen() -> None:
@@ -252,8 +284,6 @@ def info_screen(repository: str | Path, passwd: str, tag: str) -> None:
     :param tag: Git tag or branch used for the repository.
     """
     info = cookieplone_info(repository, passwd, tag)
-    title = info["title"]
-    subtitle = info["subtitle"]
     panels = info["panels"]
     columns = [
         {"title": "", "justify": "left", "style": "cyan", "no_wrap": True, "ratio": 1},
@@ -273,22 +303,17 @@ def info_screen(repository: str | Path, passwd: str, tag: str) -> None:
                     title_align="left",
                 )
             )
-    panel = Panel(
-        Group(*items),
-        title=title,
-        subtitle=subtitle,
-    )
-    base_print(panel)
+    _render_screen(items, display_banner=False)
 
 
 def enable_quiet_mode():
     """Enable quiet mode."""
-    os.environ[QUIET_MODE_VAR] = "1"
+    os.environ[settings.QUIET_MODE_VAR] = "1"
 
 
 def disable_quiet_mode():
     """Disable quiet mode."""
-    os.environ.pop(QUIET_MODE_VAR, "")
+    os.environ.pop(settings.QUIET_MODE_VAR, "")
 
 
 @contextmanager

--- a/cookieplone/utils/internal.py
+++ b/cookieplone/utils/internal.py
@@ -11,12 +11,6 @@ from pathlib import Path
 import sys
 
 
-SIGNATURE = (
-    "Made with [bold][red]❤️[/red][/bold] by the"
-    " [bold][blue]Plone Community[/blue][/bold]"
-)
-
-
 def __cookiecutter_location__() -> Path:
     """Return the cookiecutter location."""
     import cookiecutter
@@ -37,15 +31,13 @@ def version_info() -> str:
         f"Cookieplone {__version__} from {__location__()} "
         f"(Cookiecutter {__cookiecutter_version__}, "
         f"Python {python_version})\n\n"
-        f"{SIGNATURE}"
+        f"{settings.SIGNATURE}"
     )
 
 
 def cookieplone_info(repository: str | Path, passwd: str = "", tag: str = "") -> dict:
     """Print information about current configuration."""
     return {
-        "title": "cookieplone",
-        "subtitle": SIGNATURE,
         "panels": {
             "cookieplone": {
                 "title": "Installation :zap:",

--- a/news/+early-version-gate.feature
+++ b/news/+early-version-gate.feature
@@ -1,0 +1,1 @@
+Moved `min_version` check into `get_base_repository()` so version gating runs before the welcome screen. Added `sanity_screen()` for branded pre-flight error display and refactored console screens to share a `_render_screen()` helper. @ericof

--- a/news/+wizard-env-isolation.bugfix
+++ b/news/+wizard-env-isolation.bugfix
@@ -1,0 +1,1 @@
+Fixed wizard tests leaking `COOKIEPLONE_RENDERER` from the user's shell by adding a session-scoped fixture that clears the env var. @ericof

--- a/tests/utils/test_internal.py
+++ b/tests/utils/test_internal.py
@@ -33,8 +33,6 @@ def test_version_info():
 def test_cookieplone_info(panel_id: str, panel_title: str):
     result = internal.cookieplone_info(settings.REPO_DEFAULT)
     assert isinstance(result, dict)
-    assert result["title"] == "cookieplone"
-    assert result["subtitle"] == internal.SIGNATURE
     panels = result["panels"]
     assert isinstance(panels, dict)
     panel = panels[panel_id]

--- a/tests/wizard/conftest.py
+++ b/tests/wizard/conftest.py
@@ -1,11 +1,22 @@
 """Shared fixtures for wizard tests."""
 
 from cookieplone.config.state import CookieploneState
+from cookieplone.settings import RENDERER_VAR
 from tui_forms.renderer.base import BaseRenderer
 from tui_forms.renderer.cookiecutter import CookiecutterRenderer
 from unittest.mock import MagicMock
 
+import os
 import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _clean_renderer_env():
+    """Ensure COOKIEPLONE_RENDERER is unset for all wizard tests."""
+    old = os.environ.pop(RENDERER_VAR, None)
+    yield
+    if old is not None:
+        os.environ[RENDERER_VAR] = old
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

- Move `config.min_version` check into `get_base_repository()` so version gating runs **before** the welcome screen or template listing, instead of deep inside `generate()`
- Add `sanity_screen()` in `console.py` for branded pre-flight error display (version too old, etc.)
- Extract shared `_render_screen()` helper to DRY up `sanity_screen`, `welcome_screen`, and `info_screen`
- Move `SIGNATURE` constant from `utils/internal.py` to `settings.py` so it's accessible from both `console.py` and `internal.py`
- Fix wizard tests leaking `COOKIEPLONE_RENDERER` from the user's shell environment via a session-scoped fixture

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (895 tests)
- [x] Manual: set `COOKIEPLONE_RENDERER=rich` in shell, run `make test` — wizard tests should still pass
- [x] Manual: install an old cookieplone version and run against a repo with `config.min_version` set higher — error screen should appear immediately (no welcome screen)