### PR TITLE
Add pytest fixtures for testing repositories that extend an upstream

### DIFF
--- a/cookieplone/templates/extends_fixtures.py
+++ b/cookieplone/templates/extends_fixtures.py
@@ -14,11 +14,14 @@ See :doc:`/how-to-guides/test-an-extending-repository` for usage.
 from __future__ import annotations
 
 from collections.abc import Generator
+from cookieplone.config.merge import LAYERS_KEY
 from cookieplone.config.merge import normalize_extends
 from cookieplone.repository import _RESOLUTION_CACHE
 from cookieplone.repository import _load_raw_repository_config
 from cookieplone.repository import _resolve_and_merge_extends
+from copy import deepcopy
 from pathlib import Path
+from typing import Any
 
 import pytest
 import shutil
@@ -181,3 +184,60 @@ def upstream_repo_dir(
             if path.exists():
                 shutil.rmtree(path, ignore_errors=True)
         _RESOLUTION_CACHE.pop(downstream_key, None)
+
+
+@pytest.fixture
+def merged_repository_config(
+    downstream_repo_dir: Path,
+    upstream_repo_dir: Path | None,
+) -> dict[str, Any] | None:
+    """The fully-merged ``cookieplone-config.json`` dict.
+
+    Reads the cached merge result populated by
+    :func:`upstream_repo_dir`.  When the downstream declares no
+    ``extends`` (in which case ``upstream_repo_dir`` is ``None``), the
+    raw downstream config is returned unchanged — useful so a downstream
+    can write the same assertions whether or not extension is in play.
+
+    Returns a deep copy so tests may mutate the result freely without
+    affecting other tests.
+
+    .. note::
+
+       Does **not** honour ``--cookieplone-upstream-dir``: that flag is
+       a short-circuit for ``upstream_repo_dir`` only, and the merged
+       view it would produce is undefined.  Use the ``upstream_checkout``
+       fixture override to pin a specific upstream tag.
+
+    :returns: The merged config dict (downstream-wins, transitive
+        layers folded in), or ``None`` when no config can be loaded.
+    """
+    cache_key = str(downstream_repo_dir.resolve())
+    cached = _RESOLUTION_CACHE.get(cache_key)
+    if cached is not None:
+        return deepcopy(cached[0])
+    try:
+        return _load_raw_repository_config(downstream_repo_dir)
+    except RuntimeError:
+        return None
+
+
+@pytest.fixture
+def template_layers(
+    merged_repository_config: dict[str, Any] | None,
+) -> dict[str, list[list[str]]]:
+    """The ``_template_layers`` sidecar from the merged config.
+
+    Each value is the upstream-first list of ``(repo_dir, path)`` pairs
+    that contribute to a template id.  When the downstream has no
+    ``extends`` the sidecar is absent and an empty dict is returned.
+
+    Use this fixture to assert layer order without depending on internal
+    merge function names (the sidecar is a stable public contract).
+
+    :returns: Mapping of template id to its layer stack; empty when no
+        merge took place.
+    """
+    if merged_repository_config is None:
+        return {}
+    return deepcopy(merged_repository_config.get(LAYERS_KEY, {}))

--- a/cookieplone/templates/extends_fixtures.py
+++ b/cookieplone/templates/extends_fixtures.py
@@ -23,12 +23,33 @@ from cookieplone.repository import _parse_template_options
 from cookieplone.repository import _resolve_and_merge_extends
 from cookieplone.templates.bake import Result
 from copy import deepcopy
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import os
 import pytest
 import shutil
+import subprocess
+import sys
 import warnings
+
+
+@dataclass
+class SubprocessBakeResult:
+    """Captured result of a :func:`bake_in_subprocess` invocation.
+
+    :ivar exit_code: Process exit code.  ``0`` on success.
+    :ivar stdout: Captured standard output.
+    :ivar stderr: Captured standard error.
+    :ivar output_dir: The directory passed to ``-o``; project (if any)
+        is created inside.
+    """
+
+    exit_code: int
+    stdout: str
+    stderr: str
+    output_dir: Path
 
 
 CLI_UPSTREAM_DIR = "--cookieplone-upstream-dir"
@@ -340,6 +361,80 @@ def bake_from_local(
             _project_dir=project_dir,
             exception=exception,
             exit_code=exit_code,
+        )
+
+    return _bake
+
+
+@pytest.fixture
+def bake_in_subprocess(
+    downstream_repo_dir: Path,
+    upstream_repo_dir: Path | None,
+    tmp_path: Path,
+) -> Callable[..., SubprocessBakeResult]:
+    """Factory: bake via the installed ``cookieplone`` CLI in a subprocess.
+
+    Opt-in variant of :func:`bake_from_local` for end-to-end smoke tests
+    that want to exercise the real entry point rather than the in-process
+    API.  Slower than :func:`bake_from_local`; reach for it when an
+    in-process test wouldn't catch the bug (CLI argument parsing,
+    environment handling, packaging issues).
+
+    Invokes ``python -m cookieplone`` with ``--no-input``, ``-o output_dir``,
+    and ``COOKIEPLONE_REPOSITORY`` set to the downstream repo.  Extra CLI
+    arguments (a template id positional, ``EXTRA_CONTEXT`` ``key=value``
+    pairs, or other flags) are appended verbatim.
+
+    Usage::
+
+        def test_smoke(bake_in_subprocess):
+            result = bake_in_subprocess(
+                "project",                  # template id within the repo
+                "title=My Site",
+                "__folder_name=site",
+            )
+            assert result.exit_code == 0
+
+    :returns: A callable
+        ``(*cli_args, output_dir=None, env=None, timeout=120)
+            -> SubprocessBakeResult``.
+    """
+
+    def _bake(
+        *cli_args: str,
+        output_dir: Path | None = None,
+        env: dict[str, str] | None = None,
+        timeout: float | None = 120,
+    ) -> SubprocessBakeResult:
+        out_dir = output_dir if output_dir is not None else tmp_path / "out"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        cmd = [
+            sys.executable,
+            "-m",
+            "cookieplone",
+            "--no-input",
+            "-o",
+            str(out_dir),
+            *cli_args,
+        ]
+        merged_env = {
+            **os.environ,
+            "COOKIEPLONE_REPOSITORY": str(downstream_repo_dir),
+            **(env or {}),
+        }
+        run = subprocess.run(  # noqa: S603 — args are caller-controlled in tests
+            cmd,
+            capture_output=True,
+            text=True,
+            env=merged_env,
+            timeout=timeout,
+            check=False,
+        )
+        return SubprocessBakeResult(
+            exit_code=run.returncode,
+            stdout=run.stdout,
+            stderr=run.stderr,
+            output_dir=out_dir,
         )
 
     return _bake

--- a/cookieplone/templates/extends_fixtures.py
+++ b/cookieplone/templates/extends_fixtures.py
@@ -13,12 +13,15 @@ See :doc:`/how-to-guides/test-an-extending-repository` for usage.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from collections.abc import Generator
 from cookieplone.config.merge import LAYERS_KEY
 from cookieplone.config.merge import normalize_extends
 from cookieplone.repository import _RESOLUTION_CACHE
 from cookieplone.repository import _load_raw_repository_config
+from cookieplone.repository import _parse_template_options
 from cookieplone.repository import _resolve_and_merge_extends
+from cookieplone.templates.bake import Result
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
@@ -241,3 +244,102 @@ def template_layers(
     if merged_repository_config is None:
         return {}
     return deepcopy(merged_repository_config.get(LAYERS_KEY, {}))
+
+
+@pytest.fixture
+def bake_from_local(
+    downstream_repo_dir: Path,
+    upstream_repo_dir: Path | None,
+    merged_repository_config: dict[str, Any] | None,
+    tmp_path: Path,
+) -> Callable[..., Result]:
+    """Factory fixture that bakes a project from the downstream repo.
+
+    Drives :func:`cookieplone.generator.generate` in-process so the
+    test exercises the exact same code path the CLI uses, including
+    extends-aware template-file overlay.  The upstream is whatever
+    :func:`upstream_repo_dir` resolved, so a single session-scoped
+    clone backs every bake.
+
+    Output goes to *pytest*'s per-test ``tmp_path`` by default.  Pass
+    ``output_dir`` to redirect.
+
+    Usage::
+
+        def test_bake_project(bake_from_local):
+            result = bake_from_local(
+                "project",
+                extra_context={"title": "My Site"},
+            )
+            assert result.exit_code == 0
+            assert result.project_path.is_dir()
+
+    :returns: A callable
+        ``(template_id, extra_context=None, output_dir=None) -> Result``.
+        ``Result`` is :class:`cookieplone.templates.bake.Result` — exposes
+        ``exit_code``, ``exception``, and ``project_path``.
+    """
+    # Import lazily so users who never touch this fixture don't pay
+    # for the generator import chain.
+    from cookieplone._types import GenerateConfig
+    from cookieplone.generator import generate
+
+    def _bake(
+        template_id: str,
+        extra_context: dict[str, Any] | None = None,
+        output_dir: Path | None = None,
+    ) -> Result:
+        if merged_repository_config is None:
+            raise RuntimeError(
+                f"bake_from_local: no repository config found at "
+                f"{downstream_repo_dir}; cannot bake."
+            )
+        templates = _parse_template_options(
+            downstream_repo_dir, merged_repository_config, all_=True
+        )
+        if template_id not in templates:
+            raise KeyError(
+                f"Template {template_id!r} not found. Available: {sorted(templates)}"
+            )
+        tmpl = templates[template_id]
+
+        cache_key = str(downstream_repo_dir.resolve())
+        cached = _RESOLUTION_CACHE.get(cache_key)
+        cached_upstreams = list(cached[2]) if cached is not None else []
+
+        out_dir = output_dir if output_dir is not None else tmp_path
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        config = GenerateConfig(
+            repository=tmpl.origin or downstream_repo_dir,
+            template_name=tmpl.name,
+            output_dir=out_dir,
+            no_input=True,
+            extra_context=extra_context,
+            template_path=str(tmpl.path),
+            template_underlay=tmpl.underlay or None,
+            upstream_repos=cached_upstreams or None,
+            dump_answers=False,
+        )
+
+        exception: BaseException | None = None
+        exit_code = 0
+        project_dir: Path | None = None
+        try:
+            project_dir = generate(config)
+        except SystemExit as e:
+            code = e.code if isinstance(e.code, int) else 0
+            if code != 0:
+                exception = e
+            exit_code = code
+        except Exception as e:
+            exception = e
+            exit_code = -1
+
+        return Result(
+            _project_dir=project_dir,
+            exception=exception,
+            exit_code=exit_code,
+        )
+
+    return _bake

--- a/cookieplone/templates/extends_fixtures.py
+++ b/cookieplone/templates/extends_fixtures.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: 2024-present Plone Foundation <board@plone.org>
+#
+# SPDX-License-Identifier: MIT
+"""Pytest fixtures for testing downstream repositories that use the
+cookieplone ``extends`` mechanism.
+
+Auto-discovered by pytest via the ``cookieplone_extends`` entry point
+under ``[project.entry-points.pytest11]``.  Downstream repos get these
+fixtures for free as soon as ``cookieplone`` is a test dependency.
+
+See :doc:`/how-to-guides/test-an-extending-repository` for usage.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from cookieplone.config.merge import normalize_extends
+from cookieplone.repository import _RESOLUTION_CACHE
+from cookieplone.repository import _load_raw_repository_config
+from cookieplone.repository import _resolve_and_merge_extends
+from pathlib import Path
+
+import pytest
+import shutil
+import warnings
+
+
+CLI_UPSTREAM_DIR = "--cookieplone-upstream-dir"
+CLI_KEEP_UPSTREAM = "--cookieplone-keep-upstream"
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register the ``--cookieplone-upstream-dir`` and
+    ``--cookieplone-keep-upstream`` options.
+
+    Called by pytest at collection time.  Options live in the
+    ``cookieplone-extends`` group so they're discoverable via
+    ``pytest --help``.
+    """
+    group = parser.getgroup("cookieplone-extends")
+    group.addoption(
+        CLI_UPSTREAM_DIR,
+        action="store",
+        default=None,
+        dest="cookieplone_upstream_dir",
+        help=(
+            "Filesystem path to a local checkout of the upstream repository. "
+            "When set, skip the clone declared in the downstream's 'extends' "
+            "and use this directory instead. Useful when developing against "
+            "an unpushed upstream branch or when running offline."
+        ),
+    )
+    group.addoption(
+        CLI_KEEP_UPSTREAM,
+        action="store_true",
+        default=False,
+        dest="cookieplone_keep_upstream",
+        help=(
+            "Do not delete the resolved upstream clone at session end. "
+            "Useful when debugging a failing merge."
+        ),
+    )
+
+
+@pytest.fixture(scope="session")
+def downstream_repo_dir() -> Path:
+    """Local directory of the downstream repository being tested.
+
+    Defaults to the current working directory.  Override this fixture
+    when your ``cookieplone-config.json`` lives in a subdirectory.
+
+    :returns: Resolved absolute path to the downstream repo root.
+    """
+    return Path.cwd().resolve()
+
+
+@pytest.fixture(scope="session")
+def upstream_checkout() -> str | None:
+    """Optional git ref to pin the upstream to.
+
+    Overrides whatever the downstream's ``extends.tag`` says, including
+    the case where the downstream pins no tag at all.  Defaults to
+    ``None`` (use the downstream's declared tag).  Override in CI
+    matrices that test against multiple upstream versions.
+
+    :returns: Git ref to pin the upstream to, or ``None`` to use the
+        downstream's declared tag.
+    """
+    return None
+
+
+@pytest.fixture(scope="session")
+def upstream_repo_dir(
+    request: pytest.FixtureRequest,
+    downstream_repo_dir: Path,
+    upstream_checkout: str | None,
+) -> Generator[Path | None, None, None]:
+    """Local directory of the (immediate) upstream repository.
+
+    Session-scoped: the upstream is resolved (and cloned if necessary)
+    once per session and reused across tests.  Populates
+    :data:`cookieplone.repository._RESOLUTION_CACHE` so other fixtures
+    that call :func:`~cookieplone.repository.get_repository_config` for
+    the same downstream do not trigger a second clone.
+
+    Behaviour:
+
+    - When the CLI flag ``--cookieplone-upstream-dir`` is set, the
+      fixture yields that path verbatim and skips resolution entirely.
+    - When ``upstream_checkout`` is set, the resolver uses that git
+      ref instead of the downstream's ``extends.tag``.
+    - When the downstream has no ``extends``, a warning is emitted and
+      ``None`` is yielded.  Tests should ``pytest.skip()`` in that case.
+    - At session end the clone is removed unless
+      ``--cookieplone-keep-upstream`` is set.
+
+    :returns: Resolved local path to the immediate upstream, or ``None``
+        when the downstream has no ``extends``.
+    """
+    forced = request.config.getoption("cookieplone_upstream_dir", default=None)
+    if forced:
+        yield Path(forced).resolve()
+        return
+
+    try:
+        raw = _load_raw_repository_config(downstream_repo_dir)
+    except RuntimeError as exc:
+        warnings.warn(
+            f"upstream_repo_dir: could not load downstream config at "
+            f"{downstream_repo_dir}: {exc}",
+            stacklevel=2,
+        )
+        yield None
+        return
+
+    extends = raw.get("extends") if isinstance(raw, dict) else None
+    if not extends:
+        warnings.warn(
+            f"upstream_repo_dir: downstream config at {downstream_repo_dir} "
+            f"declares no 'extends'; fixture yielded None.",
+            stacklevel=2,
+        )
+        yield None
+        return
+
+    if upstream_checkout is not None:
+        normalized = normalize_extends(extends)
+        if normalized is None:
+            warnings.warn(
+                "upstream_repo_dir: downstream 'extends' is empty after "
+                "normalisation; fixture yielded None.",
+                stacklevel=2,
+            )
+            yield None
+            return
+        extends = {"url": normalized["url"], "tag": upstream_checkout}
+
+    downstream_key = str(downstream_repo_dir.resolve())
+    merged, cleanup_paths, upstream_repos = _resolve_and_merge_extends(
+        downstream_config=raw,
+        downstream_repo_dir=downstream_repo_dir.resolve(),
+        extends=extends,
+        no_input=True,
+    )
+    _RESOLUTION_CACHE[downstream_key] = (merged, cleanup_paths, upstream_repos)
+
+    if not upstream_repos:
+        warnings.warn(
+            "upstream_repo_dir: resolution produced no upstream repos. "
+            "The downstream declares 'extends' but its merged config "
+            "references no inherited templates.",
+            stacklevel=2,
+        )
+        yield None
+    else:
+        yield upstream_repos[0]
+
+    keep = request.config.getoption("cookieplone_keep_upstream", default=False)
+    if not keep:
+        for path in cleanup_paths:
+            if path.exists():
+                shutil.rmtree(path, ignore_errors=True)
+        _RESOLUTION_CACHE.pop(downstream_key, None)

--- a/docs/src/how-to-guides/extend-an-upstream-template-repository.md
+++ b/docs/src/how-to-guides/extend-an-upstream-template-repository.md
@@ -222,5 +222,6 @@ Tracking this as an opt-in append mode in [issue #185](https://github.com/plone/
 ## See also
 
 - {ref}`repo-extends`: full reference for the `extends` field and merge rules.
+- [Test an extending repository](test-an-extending-repository.md): the pytest fixtures shipped with `cookieplone` for testing a downstream that uses `extends`.
 - [Template repositories](../concepts/template-repositories.md): concept page covering repository layout and inheritance.
 - [Use a custom template repository](use-a-custom-template-repository.md): selecting any repository (with or without `extends`) at the CLI.

--- a/docs/src/how-to-guides/index.md
+++ b/docs/src/how-to-guides/index.md
@@ -37,6 +37,7 @@ add-computed-fields
 use-built-in-filters
 create-a-hidden-template
 extend-an-upstream-template-repository
+test-an-extending-repository
 call-subtemplates-from-a-hook
 run-post-gen-actions
 write-a-pre-prompt-hook

--- a/docs/src/how-to-guides/test-an-extending-repository.md
+++ b/docs/src/how-to-guides/test-an-extending-repository.md
@@ -1,0 +1,174 @@
+---
+myst:
+  html_meta:
+    "description": "Write a pytest suite for a downstream Cookieplone repository that uses extends."
+    "property=og:description": "Write a pytest suite for a downstream Cookieplone repository that uses extends."
+    "property=og:title": "Test an extending repository"
+    "keywords": "Cookieplone, extends, pytest, fixtures, downstream, testing"
+---
+
+(test-an-extending-repository)=
+
+# Test an extending repository
+
+When your downstream repository declares `extends`, you want a test suite that asserts the merge actually does what you expect: that the right templates win, that your overrides apply, that a baked codebase still produces working output.
+
+Cookieplone ships a pytest plugin that gives you this for free.
+As soon as `cookieplone` is a test dependency, a small set of fixtures becomes available through pytest's entry-point mechanism.
+
+## Prerequisites
+
+- A `cookieplone-config.json` at the root of your repository that declares `extends` (see [Extend an upstream template repository](extend-an-upstream-template-repository.md)).
+- `cookieplone` installed as a test dependency. With `uv`, add it under `[dependency-groups]` or your test extra in `pyproject.toml`:
+
+
+  ```toml
+  [dependency-groups]
+  test = [
+      "cookieplone>=2.0",
+      "pytest",
+  ]
+  ```
+
+No conftest changes are required to get started. The fixtures appear automatically.
+
+## The fixtures at a glance
+
+| Fixture | Scope | What it returns |
+|---|---|---|
+| `downstream_repo_dir` | session | Path to your repository root. Defaults to `Path.cwd()`. |
+| `upstream_checkout` | session | Optional git ref override. Defaults to `None`. |
+| `upstream_repo_dir` | session | Resolved local path to the immediate upstream. Cloned once per session and cached. |
+| `merged_repository_config` | function | The fully-merged `cookieplone-config.json` dict. |
+| `template_layers` | function | The `_template_layers` sidecar mapping each template id to its upstream-first layer stack. |
+| `bake_from_local` | function | Factory: bake a project from your repository in-process. |
+| `bake_in_subprocess` | function | Factory: bake by shelling out to the installed CLI. |
+
+## Assert the merged config
+
+The simplest thing to verify: when your downstream redeclares a template, the downstream definition wins after merging.
+
+```python
+def test_project_template_overridden(merged_repository_config):
+    project = merged_repository_config["templates"]["project"]
+    assert project["title"].startswith("My Org")
+```
+
+The fixture returns a fresh deep copy on every call, so a test that mutates the dict cannot leak into another.
+
+## Assert the layer order
+
+`template_layers` exposes the `_template_layers` sidecar as a public contract you can rely on instead of reading internal merge function names.
+
+```python
+def test_project_has_one_layer_above_upstream(template_layers):
+    layers = template_layers["project"]
+    # Upstream-first: layers[-1] is the winning (downstream) layer.
+    assert len(layers) == 2
+    upstream_repo, upstream_path = layers[0]
+    downstream_repo, downstream_path = layers[-1]
+    assert "cookieplone-templates" in upstream_repo
+```
+
+## Bake a project end-to-end
+
+`bake_from_local` is a factory that runs the same in-process generation pipeline the CLI uses, including extends-aware template-file overlay.
+
+```python
+def test_project_generates(bake_from_local):
+    result = bake_from_local(
+        "project",
+        extra_context={
+            "title": "Test Site",
+            "__folder_name": "test_site",
+            "email": "test@example.com",
+        },
+    )
+    assert result.exit_code == 0, result.exception
+    assert (result.project_path / "README.md").is_file()
+```
+
+The output goes to pytest's per-test `tmp_path` by default.
+Pass `output_dir` to redirect.
+
+If you ask for a template id that does not exist in the merged config, `bake_from_local` raises `KeyError` with the available ids listed.
+
+## Bake via the installed CLI
+
+For smoke tests that want to exercise the real entry point (argument parsing, packaging, environment handling), use `bake_in_subprocess`:
+
+```python
+def test_smoke_cli(bake_in_subprocess):
+    result = bake_in_subprocess(
+        "project",                  # template id within the repository
+        "title=Smoke Site",
+        "__folder_name=smoke",
+    )
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+```
+
+The subprocess fixture invokes `python -m cookieplone` with `COOKIEPLONE_REPOSITORY` set to your downstream repository, plus `--no-input` and `-o`. Everything else you pass goes through verbatim.
+
+subprocess tests are an order of magnitude slower than `bake_from_local`. Reach for them when the in-process test would miss the bug.
+
+## Override the resolved upstream
+
+Two override paths exist for development and CI workflows.
+
+### Pin a specific upstream version
+
+Override the `upstream_checkout` fixture in your own `conftest.py`:
+
+```python
+import pytest
+
+@pytest.fixture(scope="session")
+def upstream_checkout() -> str:
+    return "2.1.0"
+```
+
+`merged_repository_config`, `template_layers`, and the bake fixtures all honour the pin.
+
+### Use a local upstream checkout
+
+When you are developing against an upstream branch that has not yet been pushed, point pytest at a local checkout instead:
+
+```sh
+pytest --cookieplone-upstream-dir=/path/to/local/cookieplone-templates
+```
+
+This bypasses cloning entirely; `upstream_repo_dir` yields the supplied path verbatim.
+
+### Keep the clone around for debugging
+
+A failed merge often leaves you wanting to inspect the upstream tree.
+
+```sh
+pytest --cookieplone-keep-upstream
+```
+
+The clone survives session end so you can `cd` in and look around.
+
+## When the downstream has no extends
+
+The fixtures degrade gracefully:
+
+- `upstream_repo_dir` emits a warning and yields `None`.
+- `merged_repository_config` returns the raw downstream config unchanged.
+- `template_layers` returns an empty dict.
+
+This lets you write the same assertions whether or not extension is in play. Tests that genuinely require an upstream should guard explicitly:
+
+```python
+import pytest
+
+def test_requires_extends(upstream_repo_dir):
+    if upstream_repo_dir is None:
+        pytest.skip("This test requires the downstream to declare 'extends'.")
+    ...
+```
+
+## See also
+
+- [Extend an upstream template repository](extend-an-upstream-template-repository.md): how to declare and use `extends` in the first place.
+- {ref}`repo-extends`: full reference for the `extends` field and merge rules.

--- a/docs/styles/config/vocabularies/Plone/accept.txt
+++ b/docs/styles/config/vocabularies/Plone/accept.txt
@@ -67,3 +67,9 @@ uv
 Volto
 Vue
 Zope
+[Pp]ytest(11)?
+conftest
+[Ff]ixture(s)?
+pytester
+sidecar
+subprocess

--- a/news/189.feature
+++ b/news/189.feature
@@ -1,0 +1,1 @@
+Added pytest fixtures (`upstream_repo_dir`, `merged_repository_config`, `template_layers`, `bake_from_local`, `bake_in_subprocess`) so downstream repositories that use `extends` can assert their merged config and bake projects end-to-end with a single session-scoped upstream clone. @ericof

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 
 [project.entry-points.pytest11]
 cookieplone = "cookieplone.templates.fixtures"
+cookieplone_extends = "cookieplone.templates.extends_fixtures"
 
 [project.scripts]
 cookieplone = 'cookieplone.__main__:main'

--- a/tests/templates/test_extends_fixtures.py
+++ b/tests/templates/test_extends_fixtures.py
@@ -1,0 +1,228 @@
+"""Tests for cookieplone.templates.extends_fixtures."""
+
+from __future__ import annotations
+
+from cookieplone.templates import extends_fixtures
+from pathlib import Path
+from typing import Any
+
+import json
+import pytest
+
+
+def _make_repo(
+    path: Path,
+    *,
+    title: str,
+    templates: dict[str, dict[str, Any]] | None = None,
+    extends: Any = None,
+) -> Path:
+    """Materialise a minimal cookieplone repo at *path*."""
+    path.mkdir(parents=True, exist_ok=True)
+    if templates is None:
+        templates = {
+            f"{title}_tmpl": {
+                "path": f"./templates/{title}",
+                "title": f"{title} template",
+                "description": f"Template from {title}",
+                "hidden": False,
+            },
+        }
+    config: dict[str, Any] = {
+        "version": "1.0",
+        "title": title,
+        "groups": {
+            "main": {
+                "title": "Main",
+                "description": "Main group",
+                "templates": list(templates),
+                "hidden": False,
+            },
+        },
+        "templates": templates,
+    }
+    if extends is not None:
+        config["extends"] = extends
+    (path / "cookieplone-config.json").write_text(json.dumps(config))
+    return path
+
+
+# ---- In-process unit tests ---------------------------------------------------
+
+
+class TestDownstreamRepoDir:
+    def test_defaults_to_cwd(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        # Call the underlying function via __wrapped__ -- pytest fixture
+        # objects don't expose their function directly without a request.
+        assert extends_fixtures.downstream_repo_dir.__wrapped__() == tmp_path.resolve()
+
+
+class TestUpstreamCheckout:
+    def test_defaults_to_none(self):
+        assert extends_fixtures.upstream_checkout.__wrapped__() is None
+
+
+# ---- pytester end-to-end tests ----------------------------------------------
+
+
+def _make_pure_downstream(path: Path, *, extends: str) -> Path:
+    """Materialise a downstream that only declares ``extends`` (no local
+    templates or groups).  Mirrors the ``test_pure_extension_no_templates``
+    schema case.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    config = {
+        "version": "1.0",
+        "title": "Downstream",
+        "extends": extends,
+    }
+    (path / "cookieplone-config.json").write_text(json.dumps(config))
+    return path
+
+
+@pytest.fixture
+def synthetic_pair(pytester):
+    """Make an upstream + pure-extension downstream pair in
+    *pytester._path* and return their resolved paths.
+    """
+    upstream = _make_repo(pytester.path / "upstream", title="upstream")
+    downstream = _make_pure_downstream(
+        pytester.path / "downstream", extends=str(upstream.resolve())
+    )
+    return upstream.resolve(), downstream.resolve()
+
+
+def _write_conftest_pointing_at(downstream_path: Path, pytester) -> None:
+    """Write a synthetic conftest into *pytester* that overrides
+    ``downstream_repo_dir`` so the fixture resolves the synthetic pair.
+
+    Mirrors the pattern used by ``tests/templates/test_fixtures.py``.
+    """
+    pytester.makeconftest(
+        f"""
+        from pathlib import Path
+        import pytest
+
+        @pytest.fixture(scope="session")
+        def downstream_repo_dir() -> Path:
+            return Path({str(downstream_path)!r})
+        """
+    )
+
+
+def test_upstream_repo_dir_resolves(pytester, synthetic_pair):
+    upstream, downstream = synthetic_pair
+    _write_conftest_pointing_at(downstream, pytester)
+    pytester.makepyfile(
+        f"""
+        def test_resolved(upstream_repo_dir):
+            assert upstream_repo_dir is not None
+            assert str(upstream_repo_dir) == {str(upstream)!r}
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_upstream_repo_dir_yields_none_without_extends(pytester):
+    """When the downstream declares no extends, the fixture yields None
+    and emits a warning.
+    """
+    bare = _make_repo(pytester.path / "bare", title="bare")  # no extends
+    _write_conftest_pointing_at(bare.resolve(), pytester)
+    pytester.makepyfile(
+        """
+        def test_no_upstream(upstream_repo_dir):
+            assert upstream_repo_dir is None
+        """
+    )
+    result = pytester.runpytest("-W", "ignore")
+    result.assert_outcomes(passed=1)
+
+
+def test_cli_upstream_dir_short_circuits(pytester, tmp_path):
+    """``--cookieplone-upstream-dir`` bypasses resolution; the fixture
+    yields the supplied path verbatim even when the downstream has no
+    ``cookieplone-config.json``.
+    """
+    forced = tmp_path / "local-checkout"
+    forced.mkdir()
+    # Note: no downstream config required when the CLI override is set.
+    pytester.makepyfile(
+        f"""
+        def test_forced(upstream_repo_dir):
+            assert str(upstream_repo_dir) == {str(forced.resolve())!r}
+        """
+    )
+    result = pytester.runpytest(f"--cookieplone-upstream-dir={forced}")
+    result.assert_outcomes(passed=1)
+
+
+def test_upstream_checkout_override_is_passed_through(pytester, synthetic_pair):
+    """When ``upstream_checkout`` is overridden, the resolver receives
+    that tag instead of any tag declared in the downstream's extends.
+
+    We assert this by spying on ``determine_repo_dir``: at least one
+    call's ``checkout`` kwarg must be the override value.  The spy is
+    installed at session scope so it's in place before the session
+    fixture resolves.
+    """
+    _upstream, downstream = synthetic_pair
+    pytester.makeconftest(
+        f"""
+        from pathlib import Path
+        import pytest
+
+        @pytest.fixture(scope="session")
+        def downstream_repo_dir() -> Path:
+            return Path({str(downstream)!r})
+
+        @pytest.fixture(scope="session")
+        def upstream_checkout() -> str:
+            return "2.1.0"
+
+        @pytest.fixture(scope="session", autouse=True)
+        def _spy_determine_repo_dir():
+            from cookieplone import repository as r
+            seen = []
+            original = r.determine_repo_dir
+            def wrapper(**kwargs):
+                seen.append(kwargs)
+                return original(**kwargs)
+            r.determine_repo_dir = wrapper
+            yield seen
+            r.determine_repo_dir = original
+        """
+    )
+    pytester.makepyfile(
+        """
+        def test_checkout_passed(upstream_repo_dir, _spy_determine_repo_dir):
+            assert upstream_repo_dir is not None
+            assert any(
+                call.get("checkout") == "2.1.0"
+                for call in _spy_determine_repo_dir
+            )
+        """
+    )
+    result = pytester.runpytest("-W", "ignore")
+    result.assert_outcomes(passed=1)
+
+
+def test_upstream_repo_dir_populates_resolution_cache(pytester, synthetic_pair):
+    """The fixture must populate ``_RESOLUTION_CACHE`` so a subsequent
+    ``get_repository_config(downstream_repo_dir)`` call inside a test
+    does not re-clone the upstream.
+    """
+    _upstream, downstream = synthetic_pair
+    _write_conftest_pointing_at(downstream, pytester)
+    pytester.makepyfile(
+        f"""
+        from cookieplone import repository as r
+        def test_cache_populated(upstream_repo_dir):
+            assert upstream_repo_dir is not None
+            assert {str(downstream)!r} in r._RESOLUTION_CACHE
+        """
+    )
+    result = pytester.runpytest("-W", "ignore")
+    result.assert_outcomes(passed=1)

--- a/tests/templates/test_extends_fixtures.py
+++ b/tests/templates/test_extends_fixtures.py
@@ -293,6 +293,77 @@ def test_template_layers_empty_without_extends(pytester):
     result.assert_outcomes(passed=1)
 
 
+def _materialise_template(repo_root: Path, template_id: str) -> None:
+    """Create a dead-simple v1 cookiecutter template at
+    ``repo_root/templates/<template_id>/`` so a bake actually has files
+    to render.
+    """
+    tmpl_dir = repo_root / "templates" / template_id
+    tmpl_dir.mkdir(parents=True, exist_ok=True)
+    (tmpl_dir / "cookiecutter.json").write_text(
+        json.dumps({"__folder_name": "out", "title": "Hello"})
+    )
+    folder = tmpl_dir / "{{ cookiecutter.__folder_name }}"
+    folder.mkdir(exist_ok=True)
+    (folder / "README.md").write_text("# {{ cookiecutter.title }}\n")
+
+
+def test_bake_from_local_unknown_template_raises(pytester, synthetic_pair):
+    """Asking for a template id that doesn't exist after merging raises
+    ``KeyError`` with a helpful message."""
+    _upstream, downstream = synthetic_pair
+    _write_conftest_pointing_at(downstream, pytester)
+    pytester.makepyfile(
+        """
+        import pytest
+
+        def test_unknown(bake_from_local):
+            with pytest.raises(KeyError, match="does_not_exist"):
+                bake_from_local("does_not_exist")
+        """
+    )
+    result = pytester.runpytest("-W", "ignore")
+    result.assert_outcomes(passed=1)
+
+
+def test_bake_from_local_generates_project(pytester):
+    """End-to-end: a downstream extending an upstream that ships a
+    template produces a real project directory via in-process generate."""
+    upstream = _make_repo(
+        pytester.path / "upstream",
+        title="upstream",
+        templates={
+            "foo": {
+                "path": "./templates/foo",
+                "title": "Foo",
+                "description": "Foo template",
+                "hidden": False,
+            },
+        },
+    )
+    _materialise_template(upstream, "foo")
+    downstream = _make_pure_downstream(
+        pytester.path / "downstream", extends=str(upstream.resolve())
+    )
+    _write_conftest_pointing_at(downstream.resolve(), pytester)
+    pytester.makepyfile(
+        """
+        def test_bake(bake_from_local, tmp_path):
+            result = bake_from_local(
+                "foo",
+                extra_context={"__folder_name": "site", "title": "World"},
+                output_dir=tmp_path / "out",
+            )
+            assert result.exit_code == 0, result.exception
+            assert result.project_path is not None
+            assert result.project_path.is_dir()
+            assert (result.project_path / "README.md").read_text() == "# World\\n"
+        """
+    )
+    result = pytester.runpytest("-W", "ignore")
+    result.assert_outcomes(passed=1)
+
+
 def test_upstream_repo_dir_populates_resolution_cache(pytester, synthetic_pair):
     """The fixture must populate ``_RESOLUTION_CACHE`` so a subsequent
     ``get_repository_config(downstream_repo_dir)`` call inside a test

--- a/tests/templates/test_extends_fixtures.py
+++ b/tests/templates/test_extends_fixtures.py
@@ -209,6 +209,90 @@ def test_upstream_checkout_override_is_passed_through(pytester, synthetic_pair):
     result.assert_outcomes(passed=1)
 
 
+def test_merged_repository_config_with_extends(pytester, synthetic_pair):
+    """When the downstream extends an upstream, the merged config
+    carries the upstream's templates."""
+    _upstream, downstream = synthetic_pair
+    _write_conftest_pointing_at(downstream, pytester)
+    pytester.makepyfile(
+        """
+        def test_merged(merged_repository_config):
+            assert merged_repository_config is not None
+            assert "upstream_tmpl" in merged_repository_config["templates"]
+        """
+    )
+    result = pytester.runpytest("-W", "ignore")
+    result.assert_outcomes(passed=1)
+
+
+def test_merged_repository_config_without_extends(pytester):
+    """When the downstream has no extends, the fixture returns the raw
+    downstream config unchanged."""
+    bare = _make_repo(pytester.path / "bare", title="bare")
+    _write_conftest_pointing_at(bare.resolve(), pytester)
+    pytester.makepyfile(
+        """
+        def test_raw(merged_repository_config):
+            assert merged_repository_config is not None
+            assert merged_repository_config["title"] == "bare"
+            assert "bare_tmpl" in merged_repository_config["templates"]
+        """
+    )
+    result = pytester.runpytest("-W", "ignore")
+    result.assert_outcomes(passed=1)
+
+
+def test_merged_repository_config_returns_copy(pytester, synthetic_pair):
+    """Mutating the returned dict must not affect a subsequent test."""
+    _upstream, downstream = synthetic_pair
+    _write_conftest_pointing_at(downstream, pytester)
+    pytester.makepyfile(
+        """
+        def test_first(merged_repository_config):
+            merged_repository_config["title"] = "mutated"
+
+        def test_second(merged_repository_config):
+            # Same session, but a fresh copy per test.
+            assert merged_repository_config["title"] != "mutated"
+        """
+    )
+    result = pytester.runpytest("-W", "ignore")
+    result.assert_outcomes(passed=2)
+
+
+def test_template_layers_with_extends(pytester, synthetic_pair):
+    """When extending an upstream, every templates' layer list is
+    present in the sidecar."""
+    _upstream, downstream = synthetic_pair
+    _write_conftest_pointing_at(downstream, pytester)
+    pytester.makepyfile(
+        """
+        def test_layers(template_layers):
+            assert "upstream_tmpl" in template_layers
+            layers = template_layers["upstream_tmpl"]
+            assert len(layers) >= 1
+            # Each layer is [repo_dir, relative_path].
+            assert len(layers[0]) == 2
+        """
+    )
+    result = pytester.runpytest("-W", "ignore")
+    result.assert_outcomes(passed=1)
+
+
+def test_template_layers_empty_without_extends(pytester):
+    """When the downstream has no extends, the sidecar is empty."""
+    bare = _make_repo(pytester.path / "bare", title="bare")
+    _write_conftest_pointing_at(bare.resolve(), pytester)
+    pytester.makepyfile(
+        """
+        def test_no_layers(template_layers):
+            assert template_layers == {}
+        """
+    )
+    result = pytester.runpytest("-W", "ignore")
+    result.assert_outcomes(passed=1)
+
+
 def test_upstream_repo_dir_populates_resolution_cache(pytester, synthetic_pair):
     """The fixture must populate ``_RESOLUTION_CACHE`` so a subsequent
     ``get_repository_config(downstream_repo_dir)`` call inside a test

--- a/tests/templates/test_extends_fixtures.py
+++ b/tests/templates/test_extends_fixtures.py
@@ -364,6 +364,69 @@ def test_bake_from_local_generates_project(pytester):
     result.assert_outcomes(passed=1)
 
 
+def test_bake_in_subprocess_returns_nonzero_for_missing_repo(pytester, tmp_path):
+    """Smoke test: the subprocess returns a non-zero exit code when the
+    downstream points at a non-existent path.  Verifies the fixture
+    actually invokes the CLI and captures the result."""
+    missing = tmp_path / "does-not-exist"
+    pytester.makeconftest(
+        f"""
+        from pathlib import Path
+        import pytest
+
+        @pytest.fixture(scope="session")
+        def downstream_repo_dir() -> Path:
+            return Path({str(missing)!r})
+        """
+    )
+    pytester.makepyfile(
+        """
+        def test_failure(bake_in_subprocess):
+            result = bake_in_subprocess()
+            assert result.exit_code != 0
+        """
+    )
+    result = pytester.runpytest("-W", "ignore")
+    result.assert_outcomes(passed=1)
+
+
+def test_bake_in_subprocess_runs_cli(pytester):
+    """End-to-end: a real template baked via the installed CLI exits
+    cleanly and produces the expected output file."""
+    upstream = _make_repo(
+        pytester.path / "upstream",
+        title="upstream",
+        templates={
+            "foo": {
+                "path": "./templates/foo",
+                "title": "Foo",
+                "description": "Foo template",
+                "hidden": False,
+            },
+        },
+    )
+    _materialise_template(upstream, "foo")
+    downstream = _make_pure_downstream(
+        pytester.path / "downstream", extends=str(upstream.resolve())
+    )
+    _write_conftest_pointing_at(downstream.resolve(), pytester)
+    pytester.makepyfile(
+        """
+        def test_runs(bake_in_subprocess, tmp_path):
+            result = bake_in_subprocess(
+                "foo",
+                "__folder_name=site",
+                "title=Hello",
+                output_dir=tmp_path / "out",
+            )
+            assert result.exit_code == 0, (result.stdout, result.stderr)
+            assert (tmp_path / "out" / "site" / "README.md").exists()
+        """
+    )
+    result = pytester.runpytest("-W", "ignore")
+    result.assert_outcomes(passed=1)
+
+
 def test_upstream_repo_dir_populates_resolution_cache(pytester, synthetic_pair):
     """The fixture must populate ``_RESOLUTION_CACHE`` so a subsequent
     ``get_repository_config(downstream_repo_dir)`` call inside a test


### PR DESCRIPTION
## Summary

Closes #189.

Ships a pytest plugin (`cookieplone.templates.extends_fixtures`) registered as a second `pytest11` entry point so any downstream repository that uses `extends` gets a test-suite scaffold for free as soon as it depends on `cookieplone`.

The plugin exposes seven fixtures plus two CLI flags, sliced across five commits:

| Slice | Fixture / flag | Scope | What it does |
|---|---|---|---|
| 1 | `downstream_repo_dir` | session | Path to the downstream repo (defaults to `Path.cwd()`). |
| 1 | `upstream_checkout` | session | Optional git-ref override; defaults to `None`. |
| 1 | `upstream_repo_dir` | session | Resolves the immediate upstream once per session, populates `_RESOLUTION_CACHE`, cleans up at session end. |
| 1 | `--cookieplone-upstream-dir` | CLI | Short-circuit to a local checkout (offline / unpushed branches). |
| 1 | `--cookieplone-keep-upstream` | CLI | Skip the clone-cleanup at session end (debugging). |
| 2 | `merged_repository_config` | function | Deep copy of the fully-merged config (or raw downstream config when there is no `extends`). |
| 2 | `template_layers` | function | The `_template_layers` sidecar, surfaced as a stable contract. |
| 3 | `bake_from_local` | function | Factory that bakes via `cookieplone.generator.generate()` in-process; honours extends-aware overlay. |
| 4 | `bake_in_subprocess` | function | Opt-in end-to-end variant that shells out to `python -m cookieplone`. |

### Design notes

- The session-scoped `upstream_repo_dir` populates `_RESOLUTION_CACHE` so that `merged_repository_config`, `template_layers`, and both bake fixtures share a single clone per session — no parallel cache, no redundant network round-trips.
- `merged_repository_config` returns a deep copy so a test that mutates the dict cannot leak into another.
- When the downstream declares no `extends`, every fixture degrades gracefully (warning + `None` / raw config / empty dict). Downstreams that genuinely require an upstream can `pytest.skip()` explicitly.
- `bake_from_local` reuses the existing `cookieplone.templates.bake.Result` dataclass so users coming from `pytest-cookies` see a familiar shape.
- `bake_in_subprocess` sets `COOKIEPLONE_REPOSITORY` (the env var the CLI uses to locate the template repository) rather than passing the path positionally, which the CLI interprets as a template id within the repo.
- The new how-to (`docs/src/how-to-guides/test-an-extending-repository.md`) walks through each fixture and both override paths; the existing extends how-to links to it.

## Test plan

- [x] `uv run pytest` — 999 tests pass (16 new in `tests/templates/test_extends_fixtures.py`, all via `pytester` for end-to-end coverage including a real subprocess bake).
- [x] `make docs-test` — clean (vale vocab updated with `pytest`, `conftest`, `fixture(s)?`, `pytester`, `sidecar`, `subprocess`).
- [x] Pre-commit hooks clean across all five commits (ruff format, ruff check, codespell, pyroma).