### PR TITLE
Fix template merge logic to preserve allOf blocks

### DIFF
--- a/cookieplone/config/merge.py
+++ b/cookieplone/config/merge.py
@@ -258,6 +258,10 @@ def merge_template_configs(
     ds_props = ds_schema.get("properties", {})
     ups_props.update(deepcopy(ds_props))
 
+    if "allOf" in ds_schema:
+        ups_all_of = ups_schema.get("allOf", [])
+        ups_schema["allOf"] = ups_all_of + deepcopy(ds_schema["allOf"])
+
     # Merge config
     ups_config = merged.setdefault("config", {})
     ds_config = downstream.get("config", {})

--- a/news/merge-all-of.bugfix
+++ b/news/merge-all-of.bugfix
@@ -1,0 +1,1 @@
+Fixed template merge logic to correctly preserve and combine `allOf` blocks in JSON schemas. This ensures conditional questions from downstream templates are not lost during the merge process.

--- a/tests/config/test_merge_template.py
+++ b/tests/config/test_merge_template.py
@@ -1,0 +1,40 @@
+from cookieplone.config.merge import merge_template_configs
+
+def test_merge_template_configs_all_of():
+    """Verify that merge_template_configs preserves allOf blocks."""
+    upstream = {
+        "id": "upstream",
+        "schema": {
+            "version": "2.0",
+            "properties": {
+                "a": {"type": "string", "default": "upstream_a"}
+            },
+            "allOf": [
+                {"if": {"properties": {"a": {"const": "1"}}}, "then": {"properties": {"b": {"default": "2"}}}}
+            ]
+        }
+    }
+    downstream = {
+        "id": "downstream",
+        "schema": {
+            "version": "2.0",
+            "properties": {
+                "c": {"type": "string", "default": "downstream_c"}
+            },
+            "allOf": [
+                {"if": {"properties": {"c": {"const": "3"}}}, "then": {"properties": {"d": {"default": "4"}}}}
+            ]
+        }
+    }
+    
+    merged = merge_template_configs(upstream, downstream)
+    
+    assert merged["id"] == "downstream"
+    assert "a" in merged["schema"]["properties"]
+    assert "c" in merged["schema"]["properties"]
+    
+    # This is expected to FAIL without the fix
+    assert "allOf" in merged["schema"]
+    assert len(merged["schema"]["allOf"]) == 2
+    assert merged["schema"]["allOf"][0]["then"]["properties"]["b"]["default"] == "2"
+    assert merged["schema"]["allOf"][1]["then"]["properties"]["d"]["default"] == "4"

--- a/tests/config/test_merge_template.py
+++ b/tests/config/test_merge_template.py
@@ -1,38 +1,41 @@
 from cookieplone.config.merge import merge_template_configs
 
+
 def test_merge_template_configs_all_of():
     """Verify that merge_template_configs preserves allOf blocks."""
     upstream = {
         "id": "upstream",
         "schema": {
             "version": "2.0",
-            "properties": {
-                "a": {"type": "string", "default": "upstream_a"}
-            },
+            "properties": {"a": {"type": "string", "default": "upstream_a"}},
             "allOf": [
-                {"if": {"properties": {"a": {"const": "1"}}}, "then": {"properties": {"b": {"default": "2"}}}}
-            ]
-        }
+                {
+                    "if": {"properties": {"a": {"const": "1"}}},
+                    "then": {"properties": {"b": {"default": "2"}}},
+                }
+            ],
+        },
     }
     downstream = {
         "id": "downstream",
         "schema": {
             "version": "2.0",
-            "properties": {
-                "c": {"type": "string", "default": "downstream_c"}
-            },
+            "properties": {"c": {"type": "string", "default": "downstream_c"}},
             "allOf": [
-                {"if": {"properties": {"c": {"const": "3"}}}, "then": {"properties": {"d": {"default": "4"}}}}
-            ]
-        }
+                {
+                    "if": {"properties": {"c": {"const": "3"}}},
+                    "then": {"properties": {"d": {"default": "4"}}},
+                }
+            ],
+        },
     }
-    
+
     merged = merge_template_configs(upstream, downstream)
-    
+
     assert merged["id"] == "downstream"
     assert "a" in merged["schema"]["properties"]
     assert "c" in merged["schema"]["properties"]
-    
+
     # This is expected to FAIL without the fix
     assert "allOf" in merged["schema"]
     assert len(merged["schema"]["allOf"]) == 2


### PR DESCRIPTION
Discovered that `merge_template_configs` was dropping the `allOf` block from JSON schemas when merging a downstream template with an upstream one.
Since conditional questions are defined using `allOf` / `if` / `then` blocks, any conditions defined in a downstream template (custom project) were being lost.

This PR:
- Updates `merge_template_configs` to correctly append downstream `allOf` items to the upstream list.
- Adds a regression test in `tests/config/test_merge_template.py`.

This works in tandem with the fix in `tui-forms` (collective/tui-forms#23) to enable conditional questions in `cookieplone` templates.
Related `tui-forms` PR: https://github.com/collective/tui-forms/pull/23