### PR TITLE
Upgrade tui-forms to 1.0.0a5

### DIFF
--- a/news/197.internal
+++ b/news/197.internal
@@ -1,0 +1,1 @@
+Bumped the `tui-forms` dependency to `>=1.0.0a5`. @ericof

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "packaging==26.0",
   "gitpython==3.1.46",
   "xmltodict==1.0.4",
-  "tui-forms>=1.0.0a4",
+  "tui-forms>=1.0.0a5",
 ]
 
 [project.entry-points.pytest11]
@@ -68,7 +68,7 @@ dev = [
   "towncrier>=23.11.0",
   "zest-releaser[recommended]>=9.1.3",
   "zestreleaser-towncrier>=1.3.0",
-  "tui-forms[test]>=1.0.0a4",
+  "tui-forms[test]>=1.0.0a5",
 ]
 
 docs = [

--- a/uv.lock
+++ b/uv.lock
@@ -510,7 +510,7 @@ dev = [
     { name = "pytest", specifier = "==8.1.1" },
     { name = "pytest-cov", specifier = "==5.0.0" },
     { name = "towncrier", specifier = ">=23.11.0" },
-    { name = "tui-forms", extras = ["test"], specifier = ">=1.0.0a4" },
+    { name = "tui-forms", extras = ["test"], specifier = ">=1.0.0a5" },
     { name = "zest-releaser", extras = ["recommended"], specifier = ">=9.1.3" },
     { name = "zestreleaser-towncrier", specifier = ">=1.3.0" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -497,7 +497,7 @@ requires-dist = [
     { name = "gitpython", specifier = "==3.1.46" },
     { name = "packaging", specifier = "==26.0" },
     { name = "semver", specifier = "==3.0.4" },
-    { name = "tui-forms", specifier = ">=1.0.0a4" },
+    { name = "tui-forms", specifier = ">=1.0.0a5" },
     { name = "typer", specifier = "==0.24.1" },
     { name = "xmltodict", specifier = "==1.0.4" },
 ]
@@ -2318,15 +2318,15 @@ wheels = [
 
 [[package]]
 name = "tui-forms"
-version = "1.0.0a4"
+version = "1.0.0a5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
     { name = "jsonschema" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/43/8a95ae4b08d4109702df4cb29d51de6c623625ffb73fdbc93e0bdf693047/tui_forms-1.0.0a4.tar.gz", hash = "sha256:8c7cb0ceb5c60a3f83e693088be25de37f27cd930270f6a6a08936b7f302b0c8", size = 30320, upload-time = "2026-04-02T14:15:24.03Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/2a/03988f197635f4f764922229b8ce21ffa23a5aca6b6ddb9ca92694459193/tui_forms-1.0.0a5.tar.gz", hash = "sha256:ed6c0ab2244bee3dbba24bbe33a5ccd08cab4c1d33780e1541ac8ad954a807c7", size = 1165235, upload-time = "2026-05-22T22:33:12.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/b5/c7dc9108d172467d4f1f9590994a627a7b90f36f34485fb9d87e448951aa/tui_forms-1.0.0a4-py3-none-any.whl", hash = "sha256:a8274fbfd754fb18ba9d149a2f881447986aa4bc70ab558e7ef131b94ebbe7df", size = 41049, upload-time = "2026-04-02T14:15:25.369Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/3d/717f24a25ab2e0463881da37d3ca3df589749e4644c955a22f3e8a8d4228/tui_forms-1.0.0a5-py3-none-any.whl", hash = "sha256:5a11bb4736a871bbec573629b87d12e8be71ad4b0885f48e887c0b5323625f8a", size = 1629724, upload-time = "2026-05-22T22:33:15.438Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Bumps `tui-forms` from `>=1.0.0a4` to `>=1.0.0a5` in both the runtime
dependencies and the `dev` test extras of `pyproject.toml`. `uv.lock` is
refreshed accordingly.

## Test plan

- [x] `make test` — 1015 passed, no regressions vs. main
- [x] CI green

Closes #197