### PR TITLE
Fix computed field overwrites by user context

### DIFF
--- a/cookieplone/config/state.py
+++ b/cookieplone/config/state.py
@@ -143,6 +143,49 @@ def _filter_initial_answers(
     return data
 
 
+def _apply_overwrite_to_property(
+    variable: str,
+    property_: dict[str, Any],
+    overwrite: Any,
+    in_dictionary_variable: bool = False,
+):
+    """Apply a single overwrite to a property definition."""
+    context_value = property_.get("default")
+    if isinstance(context_value, list):
+        if in_dictionary_variable:
+            property_["default"] = overwrite
+            return
+        if isinstance(overwrite, list):
+            # We are dealing with a multichoice variable
+            # Let's confirm all choices are valid for the given context
+            if set(overwrite).issubset(set(context_value)):
+                property_["default"] = overwrite
+            else:
+                raise ValueError(
+                    f"{overwrite} provided for multi-choice variable "
+                    f"{variable}, but valid choices are {context_value}"
+                )
+        else:
+            # We are dealing with a choice variable
+            if overwrite in context_value:
+                # This overwrite is actually valid for the given context
+                # Let's set it as default (by definition first item in list)
+                # see ``cookiecutter.prompt.prompt_choice_for_config``
+                context_value.remove(overwrite)
+                context_value.insert(0, overwrite)
+            else:
+                raise ValueError(
+                    f"{overwrite} provided for choice variable "
+                    f"{variable}, but the choices are {context_value}."
+                )
+    elif isinstance(context_value, dict) and isinstance(overwrite, dict):
+        # Partially overwrite some keys in original dict
+        _apply_overwrites_to_schema(property_, overwrite, in_dictionary_variable=True)
+    else:
+        # Simply overwrite the value for this variable
+        property_["default"] = overwrite
+
+
 def _apply_overwrites_to_schema(
     schema: dict[str, Any],
     overwrite_context: dict[str, Any],
@@ -179,42 +222,9 @@ def _apply_overwrites_to_schema(
             properties[variable] = {"default": overwrite}
 
         property_ = properties.get(variable, _NO_VALUE)
-        context_value = property_.get("default")
-        if isinstance(context_value, list):
-            if in_dictionary_variable:
-                property_["default"] = overwrite
-                continue
-            if isinstance(overwrite, list):
-                # We are dealing with a multichoice variable
-                # Let's confirm all choices are valid for the given context
-                if set(overwrite).issubset(set(context_value)):
-                    property_["default"] = overwrite
-                else:
-                    raise ValueError(
-                        f"{overwrite} provided for multi-choice variable "
-                        f"{variable}, but valid choices are {context_value}"
-                    )
-            else:
-                # We are dealing with a choice variable
-                if overwrite in context_value:
-                    # This overwrite is actually valid for the given context
-                    # Let's set it as default (by definition first item in list)
-                    # see ``cookiecutter.prompt.prompt_choice_for_config``
-                    context_value.remove(overwrite)
-                    context_value.insert(0, overwrite)
-                else:
-                    raise ValueError(
-                        f"{overwrite} provided for choice variable "
-                        f"{variable}, but the choices are {context_value}."
-                    )
-        elif isinstance(context_value, dict) and isinstance(overwrite, dict):
-            # Partially overwrite some keys in original dict
-            _apply_overwrites_to_schema(
-                property_, overwrite, in_dictionary_variable=True
-            )
-        else:
-            # Simply overwrite the value for this variable
-            property_["default"] = overwrite
+        _apply_overwrite_to_property(
+            variable, property_, overwrite, in_dictionary_variable
+        )
 
     # Apply overwrites to allOf blocks
     for item in schema.get("allOf", []):

--- a/cookieplone/config/state.py
+++ b/cookieplone/config/state.py
@@ -210,12 +210,21 @@ def _apply_overwrites_to_schema(
         elif isinstance(context_value, dict) and isinstance(overwrite, dict):
             # Partially overwrite some keys in original dict
             _apply_overwrites_to_schema(
-                context_value, overwrite, in_dictionary_variable=True
+                property_, overwrite, in_dictionary_variable=True
             )
-            property_["default"] = context_value
         else:
             # Simply overwrite the value for this variable
             property_["default"] = overwrite
+
+    # Apply overwrites to allOf blocks
+    for item in schema.get("allOf", []):
+        for block in ("then", "else"):
+            if block in item:
+                _apply_overwrites_to_schema(
+                    item[block],
+                    overwrite_context,
+                    in_dictionary_variable=in_dictionary_variable,
+                )
 
 
 def _merge_versions(
@@ -280,6 +289,7 @@ def _generate_state(
         # to apply default values from the context
         for additional_context in (default_context, extra_context):
             if additional_context:
+                data.update(additional_context)
                 initial_data.update(additional_context)
                 try:
                     _apply_overwrites_to_schema(schema, additional_context)

--- a/news/200.bugfix
+++ b/news/200.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where user-provided context for computed fields was being overwritten by schema defaults. It also adds support for recursive overrides in allOf blocks. @erral

--- a/news/200.internal
+++ b/news/200.internal
@@ -1,0 +1,1 @@
+Bumped the `tui-forms` dependency to `>=1.0.0b1`. @ericof

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "packaging==26.0",
   "gitpython==3.1.46",
   "xmltodict==1.0.4",
-  "tui-forms>=1.0.0a5",
+  "tui-forms>=1.0.0b1",
 ]
 
 [project.entry-points.pytest11]
@@ -68,7 +68,7 @@ dev = [
   "towncrier>=23.11.0",
   "zest-releaser[recommended]>=9.1.3",
   "zestreleaser-towncrier>=1.3.0",
-  "tui-forms[test]>=1.0.0a5",
+  "tui-forms[test]>=1.0.0b1",
 ]
 
 docs = [

--- a/tests/config/test_apply_overwrites_recursive.py
+++ b/tests/config/test_apply_overwrites_recursive.py
@@ -1,0 +1,67 @@
+from cookieplone.config.state import _apply_overwrites_to_schema
+from cookieplone.config.state import _generate_state
+from cookieplone.config.v2 import ParsedConfig
+import pytest
+
+def test_apply_overwrites_to_schema_recursive():
+    """Verify that overwrites are applied recursively to allOf blocks."""
+    schema = {
+        "properties": {
+            "base_key": {"default": "base_default"}
+        },
+        "allOf": [
+            {
+                "if": {"properties": {"some_flag": {"const": True}}},
+                "then": {
+                    "properties": {
+                        "nested_key": {"default": "nested_default"}
+                    }
+                },
+                "else": {
+                    "properties": {
+                        "other_key": {"default": "else_default"}
+                    }
+                }
+            }
+        ]
+    }
+    overwrites = {
+        "base_key": "base_overridden",
+        "nested_key": "nested_overridden",
+        "other_key": "else_overridden"
+    }
+    
+    _apply_overwrites_to_schema(schema, overwrites)
+    
+    assert schema["properties"]["base_key"]["default"] == "base_overridden"
+    assert schema["allOf"][0]["then"]["properties"]["nested_key"]["default"] == "nested_overridden"
+    assert schema["allOf"][0]["else"]["properties"]["other_key"]["default"] == "else_overridden"
+
+def test_generate_state_propagates_overrides_to_data():
+    """Verify that extra_context overrides end up in the data dict for the renderer."""
+    parsed = ParsedConfig(
+        schema={
+            "properties": {
+                "computed_field": {
+                    "type": "string",
+                    "default": "default-value",
+                    "format": "computed"
+                }
+            }
+        },
+        extensions=[],
+        no_render=[],
+        subtemplates=[],
+        template_id="test",
+        versions={}
+    )
+    
+    extra_context = {"computed_field": "user-override"}
+    
+    # We use _generate_state directly to avoid loading from disk
+    state = _generate_state(parsed, extra_context=extra_context)
+    
+    # Check that it's in the data dict (initial answers for the renderer)
+    assert state.data["cookiecutter"]["computed_field"] == "user-override"
+    # Check that it's also in the schema default
+    assert state.schema["properties"]["computed_field"]["default"] == "user-override"

--- a/tests/config/test_apply_overwrites_recursive.py
+++ b/tests/config/test_apply_overwrites_recursive.py
@@ -1,41 +1,38 @@
 from cookieplone.config.state import _apply_overwrites_to_schema
 from cookieplone.config.state import _generate_state
 from cookieplone.config.v2 import ParsedConfig
-import pytest
+
 
 def test_apply_overwrites_to_schema_recursive():
     """Verify that overwrites are applied recursively to allOf blocks."""
     schema = {
-        "properties": {
-            "base_key": {"default": "base_default"}
-        },
+        "properties": {"base_key": {"default": "base_default"}},
         "allOf": [
             {
                 "if": {"properties": {"some_flag": {"const": True}}},
-                "then": {
-                    "properties": {
-                        "nested_key": {"default": "nested_default"}
-                    }
-                },
-                "else": {
-                    "properties": {
-                        "other_key": {"default": "else_default"}
-                    }
-                }
+                "then": {"properties": {"nested_key": {"default": "nested_default"}}},
+                "else": {"properties": {"other_key": {"default": "else_default"}}},
             }
-        ]
+        ],
     }
     overwrites = {
         "base_key": "base_overridden",
         "nested_key": "nested_overridden",
-        "other_key": "else_overridden"
+        "other_key": "else_overridden",
     }
-    
+
     _apply_overwrites_to_schema(schema, overwrites)
-    
+
     assert schema["properties"]["base_key"]["default"] == "base_overridden"
-    assert schema["allOf"][0]["then"]["properties"]["nested_key"]["default"] == "nested_overridden"
-    assert schema["allOf"][0]["else"]["properties"]["other_key"]["default"] == "else_overridden"
+    assert (
+        schema["allOf"][0]["then"]["properties"]["nested_key"]["default"]
+        == "nested_overridden"
+    )
+    assert (
+        schema["allOf"][0]["else"]["properties"]["other_key"]["default"]
+        == "else_overridden"
+    )
+
 
 def test_generate_state_propagates_overrides_to_data():
     """Verify that extra_context overrides end up in the data dict for the renderer."""
@@ -45,7 +42,7 @@ def test_generate_state_propagates_overrides_to_data():
                 "computed_field": {
                     "type": "string",
                     "default": "default-value",
-                    "format": "computed"
+                    "format": "computed",
                 }
             }
         },
@@ -53,14 +50,14 @@ def test_generate_state_propagates_overrides_to_data():
         no_render=[],
         subtemplates=[],
         template_id="test",
-        versions={}
+        versions={},
     )
-    
+
     extra_context = {"computed_field": "user-override"}
-    
+
     # We use _generate_state directly to avoid loading from disk
     state = _generate_state(parsed, extra_context=extra_context)
-    
+
     # Check that it's in the data dict (initial answers for the renderer)
     assert state.data["cookiecutter"]["computed_field"] == "user-override"
     # Check that it's also in the schema default

--- a/uv.lock
+++ b/uv.lock
@@ -497,7 +497,7 @@ requires-dist = [
     { name = "gitpython", specifier = "==3.1.46" },
     { name = "packaging", specifier = "==26.0" },
     { name = "semver", specifier = "==3.0.4" },
-    { name = "tui-forms", specifier = ">=1.0.0a5" },
+    { name = "tui-forms", specifier = ">=1.0.0b1" },
     { name = "typer", specifier = "==0.24.1" },
     { name = "xmltodict", specifier = "==1.0.4" },
 ]
@@ -510,7 +510,7 @@ dev = [
     { name = "pytest", specifier = "==8.1.1" },
     { name = "pytest-cov", specifier = "==5.0.0" },
     { name = "towncrier", specifier = ">=23.11.0" },
-    { name = "tui-forms", extras = ["test"], specifier = ">=1.0.0a5" },
+    { name = "tui-forms", extras = ["test"], specifier = ">=1.0.0b1" },
     { name = "zest-releaser", extras = ["recommended"], specifier = ">=9.1.3" },
     { name = "zestreleaser-towncrier", specifier = ">=1.3.0" },
 ]
@@ -2318,15 +2318,15 @@ wheels = [
 
 [[package]]
 name = "tui-forms"
-version = "1.0.0a5"
+version = "1.0.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
     { name = "jsonschema" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/2a/03988f197635f4f764922229b8ce21ffa23a5aca6b6ddb9ca92694459193/tui_forms-1.0.0a5.tar.gz", hash = "sha256:ed6c0ab2244bee3dbba24bbe33a5ccd08cab4c1d33780e1541ac8ad954a807c7", size = 1165235, upload-time = "2026-05-22T22:33:12.448Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/ad/cdda14f5f8fb14623581ea1b214ff02c0208488fa58c80d0187dde946372/tui_forms-1.0.0b1.tar.gz", hash = "sha256:7a9ec3ffaaef4009c5672b9bd7bcad7592c41540f0a17871f33d276f77a94ff6", size = 1165600, upload-time = "2026-05-29T15:17:49.061Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/3d/717f24a25ab2e0463881da37d3ca3df589749e4644c955a22f3e8a8d4228/tui_forms-1.0.0a5-py3-none-any.whl", hash = "sha256:5a11bb4736a871bbec573629b87d12e8be71ad4b0885f48e887c0b5323625f8a", size = 1629724, upload-time = "2026-05-22T22:33:15.438Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/45/64e7bc5a93094553e5bdf534ff2d832d2e6d216121d9ca53c651702c674c/tui_forms-1.0.0b1-py3-none-any.whl", hash = "sha256:a6e9b0ce30ebb794bd85da66eb92ff088afcfd5389bbfcec59e7edb13ef89d5d", size = 1629920, upload-time = "2026-05-29T15:17:46.973Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
This PR fixes an issue where user-provided context for computed fields was being overwritten by schema defaults. It also adds support for recursive overrides in allOf blocks. 

Requires changes in tui-forms to fully pass tests in cookieplone-templates.