### PR TITLE
Upgrade dependencies and adapt to Typer's vendored Click (#199)

### DIFF
--- a/news/+cookiecutter-271.internal
+++ b/news/+cookiecutter-271.internal
@@ -1,0 +1,1 @@
+Upgraded `cookiecutter` to 2.7.1. @ericof

--- a/news/+gitpython-3150.internal
+++ b/news/+gitpython-3150.internal
@@ -1,0 +1,1 @@
+Upgraded `gitpython` to 3.1.50. @ericof

--- a/news/+packaging-262.internal
+++ b/news/+packaging-262.internal
@@ -1,0 +1,1 @@
+Upgraded `packaging` to 26.2. @ericof

--- a/news/199.internal
+++ b/news/199.internal
@@ -1,0 +1,1 @@
+Upgraded `typer` to 0.26.0 and adapted to Typer's vendored Click. Typer no longer depends on the external `click` package, so the test suite now catches `BadParameter` via Typer's public export. @ericof

--- a/news/199.internal
+++ b/news/199.internal
@@ -1,1 +1,1 @@
-Upgraded `typer` to 0.26.0 and adapted to Typer's vendored Click. Typer no longer depends on the external `click` package, so the test suite now catches `BadParameter` via Typer's public export. @ericof
+Upgraded `typer` to 0.26.4 and adapted to Typer's vendored Click. Typer no longer depends on the external `click` package, so the test suite now catches `BadParameter` via Typer's public export. @ericof

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
   "cookiecutter==2.6.0",
   "semver==3.0.4",
-  "typer==0.24.1",
+  "typer==0.26.0",
   "packaging==26.0",
   "gitpython==3.1.46",
   "xmltodict==1.0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Topic :: Software Development :: Code Generators",
 ]
 dependencies = [
-  "cookiecutter==2.6.0",
+  "cookiecutter==2.7.1",
   "semver==3.0.4",
   "typer==0.26.0",
   "packaging==26.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "semver==3.0.4",
   "typer==0.26.4",
   "packaging==26.2",
-  "gitpython==3.1.46",
+  "gitpython==3.1.50",
   "xmltodict==1.0.4",
   "tui-forms>=1.0.0b1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
   "cookiecutter==2.7.1",
   "semver==3.0.4",
-  "typer==0.26.0",
+  "typer==0.26.4",
   "packaging==26.0",
   "gitpython==3.1.46",
   "xmltodict==1.0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "cookiecutter==2.7.1",
   "semver==3.0.4",
   "typer==0.26.4",
-  "packaging==26.0",
+  "packaging==26.2",
   "gitpython==3.1.46",
   "xmltodict==1.0.4",
   "tui-forms>=1.0.0b1",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
-from click.exceptions import BadParameter
 from cookieplone import cli
 from cookieplone.exceptions import RepositoryException
 from cookieplone.exceptions import VersionTooOldException
+from typer import BadParameter
 from typer.testing import CliRunner
 
 import pytest

--- a/uv.lock
+++ b/uv.lock
@@ -498,7 +498,7 @@ requires-dist = [
     { name = "packaging", specifier = "==26.0" },
     { name = "semver", specifier = "==3.0.4" },
     { name = "tui-forms", specifier = ">=1.0.0b1" },
-    { name = "typer", specifier = "==0.26.0" },
+    { name = "typer", specifier = "==0.26.4" },
     { name = "xmltodict", specifier = "==1.0.4" },
 ]
 
@@ -2356,7 +2356,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.26.0"
+version = "0.26.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -2364,9 +2364,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/db/25a5e308af68fda1cc49a4423eded2a7cad1381fbc1f7a4d5502d6fe26c6/typer-0.26.0.tar.gz", hash = "sha256:08177aa85fd81ceb6e8f7cb879cf22dbaa81f98c02b7d570acf112513d2aa66f", size = 198809, upload-time = "2026-05-26T14:37:09.446Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/d3/90c1ee19209cb59f6ad185883fd4ccfcf72f8f0bfd549d5a8b70474611d0/typer-0.26.4.tar.gz", hash = "sha256:25b128964de66c5ea36d5ac82adc579e5e113509b17469edf9f5a4a1864ff2a9", size = 201191, upload-time = "2026-05-30T17:05:04.213Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/e1/01faefdf98e3a05ca5f3487caabab033fda84c5bd1bae7f73b8bb5dd553e/typer-0.26.0-py3-none-any.whl", hash = "sha256:859d520a4dc91c075cb370195462b6f7024fceb5d6de5c204bb8b1d51a60ad66", size = 123093, upload-time = "2026-05-26T14:37:07.783Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/6d/5a525c69df4a90892135e5d490b00e9e46402491f3416d4395fcb0d0201e/typer-0.26.4-py3-none-any.whl", hash = "sha256:11bfd7b43557137e373c2b10f6967a555f9678a61ed72c808968b011d95534d6", size = 122436, upload-time = "2026-05-30T17:05:05.812Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -498,7 +498,7 @@ requires-dist = [
     { name = "packaging", specifier = "==26.0" },
     { name = "semver", specifier = "==3.0.4" },
     { name = "tui-forms", specifier = ">=1.0.0b1" },
-    { name = "typer", specifier = "==0.24.1" },
+    { name = "typer", specifier = "==0.26.0" },
     { name = "xmltodict", specifier = "==1.0.4" },
 ]
 
@@ -2356,17 +2356,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.24.1"
+version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/db/25a5e308af68fda1cc49a4423eded2a7cad1381fbc1f7a4d5502d6fe26c6/typer-0.26.0.tar.gz", hash = "sha256:08177aa85fd81ceb6e8f7cb879cf22dbaa81f98c02b7d570acf112513d2aa66f", size = 198809, upload-time = "2026-05-26T14:37:09.446Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+    { url = "https://files.pythonhosted.org/packages/64/e1/01faefdf98e3a05ca5f3487caabab033fda84c5bd1bae7f73b8bb5dd553e/typer-0.26.0-py3-none-any.whl", hash = "sha256:859d520a4dc91c075cb370195462b6f7024fceb5d6de5c204bb8b1d51a60ad66", size = 123093, upload-time = "2026-05-26T14:37:07.783Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "cookiecutter", specifier = "==2.7.1" },
-    { name = "gitpython", specifier = "==3.1.46" },
+    { name = "gitpython", specifier = "==3.1.50" },
     { name = "packaging", specifier = "==26.2" },
     { name = "semver", specifier = "==3.0.4" },
     { name = "tui-forms", specifier = ">=1.0.0b1" },
@@ -765,14 +765,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.46"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "cookiecutter"
-version = "2.6.0"
+version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "arrow" },
@@ -436,9 +436,9 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/17/9f2cd228eb949a91915acd38d3eecdc9d8893dde353b603f0db7e9f6be55/cookiecutter-2.6.0.tar.gz", hash = "sha256:db21f8169ea4f4fdc2408d48ca44859349de2647fbe494a9d6c3edfc0542c21c", size = 158767, upload-time = "2024-02-21T18:02:41.949Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/03/f4c96d8fd4f5e8af0210bf896eb63927f35d3014a8e8f3bf9d2c43ad3332/cookiecutter-2.7.1.tar.gz", hash = "sha256:ca7bb7bc8c6ff441fbf53921b5537668000e38d56e28d763a1b73975c66c6138", size = 142854, upload-time = "2026-03-04T04:06:02.786Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/d9/0137658a353168ffa9d0fc14b812d3834772040858ddd1cb6eeaf09f7a44/cookiecutter-2.6.0-py3-none-any.whl", hash = "sha256:a54a8e37995e4ed963b3e82831072d1ad4b005af736bb17b99c2cbd9d41b6e2d", size = 39177, upload-time = "2024-02-21T18:02:39.569Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a9/8c855c14b401dc67d20739345295af5afce5e930a69600ab20f6cfa50b5c/cookiecutter-2.7.1-py3-none-any.whl", hash = "sha256:cee50defc1eaa7ad0071ee9b9893b746c1b3201b66bf4d3686d0f127c8ed6cf9", size = 41317, upload-time = "2026-03-04T04:06:01.221Z" },
 ]
 
 [[package]]
@@ -493,7 +493,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cookiecutter", specifier = "==2.6.0" },
+    { name = "cookiecutter", specifier = "==2.7.1" },
     { name = "gitpython", specifier = "==3.1.46" },
     { name = "packaging", specifier = "==26.0" },
     { name = "semver", specifier = "==3.0.4" },

--- a/uv.lock
+++ b/uv.lock
@@ -495,7 +495,7 @@ docs = [
 requires-dist = [
     { name = "cookiecutter", specifier = "==2.7.1" },
     { name = "gitpython", specifier = "==3.1.46" },
-    { name = "packaging", specifier = "==26.0" },
+    { name = "packaging", specifier = "==26.2" },
     { name = "semver", specifier = "==3.0.4" },
     { name = "tui-forms", specifier = ">=1.0.0b1" },
     { name = "typer", specifier = "==0.26.4" },
@@ -1217,11 +1217,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Batch of dependency upgrades, driven by the analysis in #199 of Typer's decision to vendor Click.

### Typer & the vendored Click (#199)

Typer 0.26.x stops depending on the external `click` package and ships a **vendored** copy as `typer._click`. Impact analysis on cookieplone:

- **App code** — [`cookieplone/cli/__init__.py`](cookieplone/cli/__init__.py) already raises `typer.BadParameter`, which follows the symbol wherever Typer points it. No change needed.
- **Test code** — `tests/test_cli.py` was the only place importing the external `click`. It now catches `BadParameter` via Typer's **public** export (`from typer import BadParameter`), matching exactly what the app raises and avoiding any private (`typer._click`) path.
- **External `click`** is now only an incidental transitive dependency (via `cookiecutter`); cookieplone no longer couples to it directly.

### Dependency bumps

- `typer` 0.24.1 → **0.26.4**
- `cookiecutter` 2.6.0 → **2.7.1**
- `packaging` 26.0 → **26.2**
- `gitpython` 3.1.46 → **3.1.50**

## Testing

Full suite passes (1017 passed) on every bump.

Closes #199