### PR TITLE
Keep confirmation screen in form order

### DIFF
--- a/news/202.bugfix
+++ b/news/202.bugfix
@@ -1,0 +1,1 @@
+The confirmation screen now always preserves the order of the form questions. @ericof

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "packaging==26.2",
   "gitpython==3.1.50",
   "xmltodict==1.0.4",
-  "tui-forms>=1.0.0b1",
+  "tui-forms>=1.0.0b2",
 ]
 
 [project.entry-points.pytest11]

--- a/tests/wizard/test_confirmation_order.py
+++ b/tests/wizard/test_confirmation_order.py
@@ -1,0 +1,48 @@
+"""Tests for confirmation-screen answer ordering (issue #202).
+
+The confirmation screen shown after all answers are supplied is rendered by
+tui-forms' ``render_summary``, which iterates ``form.user_answers.items()``.
+The order the user sees is therefore exactly the iteration order of
+``user_answers``.
+
+These tests assert that ``user_answers`` preserves the order in which the
+questions were declared in the schema. They fail while ``user_answers`` is
+built by iterating an unordered set, and pass once insertion order is kept.
+"""
+
+# A schema with enough fields that an unordered iteration reliably diverges
+# from the declared order (the probability of a set happening to iterate in
+# declaration order across this many keys is negligible).
+SCHEMA_ORDERED = {
+    "title": "Test Form",
+    "description": "",
+    "type": "object",
+    "properties": {
+        "title": {"type": "string", "default": "My Project"},
+        "description": {"type": "string", "default": "A project"},
+        "author": {"type": "string", "default": "Jane Doe"},
+        "email": {"type": "string", "default": "jane@example.com"},
+        "python_package_name": {"type": "string", "default": "my.project"},
+        "volto_addon_name": {"type": "string", "default": "volto-my-addon"},
+        "license": {"type": "string", "default": "GPLv2"},
+        "workflow": {"type": "string", "default": "default"},
+    },
+    "required": [],
+}
+
+
+class TestConfirmationScreenOrder:
+    """The confirmation screen must list answers in the schema's question order."""
+
+    def test_user_answers_preserve_question_order(self, make_form, render_form):
+        """``form.user_answers`` (the data the confirmation screen iterates)
+        must follow the order the questions were declared in the schema."""
+        frm = make_form(SCHEMA_ORDERED, root_key="cookiecutter")
+        expected = list(SCHEMA_ORDERED["properties"].keys())
+        # Accept every default in order (empty input == accept default), which
+        # records each key as user-provided.
+        render_form(frm, [""] * len(expected))
+        assert list(frm.user_answers.keys()) == expected, (
+            "The confirmation screen does not preserve the form's question "
+            "order (issue #202)."
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -497,7 +497,7 @@ requires-dist = [
     { name = "gitpython", specifier = "==3.1.50" },
     { name = "packaging", specifier = "==26.2" },
     { name = "semver", specifier = "==3.0.4" },
-    { name = "tui-forms", specifier = ">=1.0.0b1" },
+    { name = "tui-forms", specifier = ">=1.0.0b2" },
     { name = "typer", specifier = "==0.26.4" },
     { name = "xmltodict", specifier = "==1.0.4" },
 ]
@@ -2318,15 +2318,15 @@ wheels = [
 
 [[package]]
 name = "tui-forms"
-version = "1.0.0b1"
+version = "1.0.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
     { name = "jsonschema" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/ad/cdda14f5f8fb14623581ea1b214ff02c0208488fa58c80d0187dde946372/tui_forms-1.0.0b1.tar.gz", hash = "sha256:7a9ec3ffaaef4009c5672b9bd7bcad7592c41540f0a17871f33d276f77a94ff6", size = 1165600, upload-time = "2026-05-29T15:17:49.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/f4/d322a781d50373ba3ac72a251a1c5bfd75bcac1b8cf532ca9754804df3ee/tui_forms-1.0.0b2.tar.gz", hash = "sha256:05603a5c528eba9d0b10843175fdc69e0316ff5955bd89d9c7d3b1e72ba17aee", size = 1165541, upload-time = "2026-06-05T19:52:29.713Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/45/64e7bc5a93094553e5bdf534ff2d832d2e6d216121d9ca53c651702c674c/tui_forms-1.0.0b1-py3-none-any.whl", hash = "sha256:a6e9b0ce30ebb794bd85da66eb92ff088afcfd5389bbfcec59e7edb13ef89d5d", size = 1629920, upload-time = "2026-05-29T15:17:46.973Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/6d/f84e2ab64417ec817da909c708d2ad88115b01fac59006f0cafe6f86d9ab/tui_forms-1.0.0b2-py3-none-any.whl", hash = "sha256:0ce11ede01bc4c6fc541fe7ab4eb10cdc7e3d722bb6c10af742ed3169854b4de", size = 1629936, upload-time = "2026-06-05T19:52:31.304Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

The confirmation screen — shown after all form answers are supplied — now always preserves the order in which the questions were declared in the schema.

## Details

The confirmation summary is rendered by tui-forms' `render_summary`, which iterates `form.user_answers`. In `tui-forms` 1.0.0b1, `user_answers` was built by iterating an unordered set, so the answers were displayed in an arbitrary order rather than the form's question order.

- Bumped `tui-forms` to `1.0.0b2`, which builds `user_answers` in the declared question order.
- Added a regression test (`tests/wizard/test_confirmation_order.py`) that answers an 8-field form in declaration order and asserts `form.user_answers` preserves that order. It fails on `1.0.0b1` and passes on `1.0.0b2`.

## Testing

- `make lint` — passes
- `uv run pytest` — 1018 passed

Closes #202