### PR TITLE
Add post-generation summary screen

### DIFF
--- a/cookieplone/_types.py
+++ b/cookieplone/_types.py
@@ -67,6 +67,7 @@ class RepositoryInfo:
     config_dict: dict[str, Any]
     global_versions: dict[str, str] = field(default_factory=dict)
     renderer: str = ""
+    summary: dict[str, Any] = field(default_factory=dict)
     cleanup_paths: list[Path] = field(default_factory=list)
     upstream_repos: list[Path] = field(default_factory=list)
 
@@ -124,4 +125,52 @@ class GenerateConfig:
             overwrite_if_exists=self.overwrite_if_exists,
             skip_if_file_exists=self.skip_if_file_exists,
             keep_project_on_failure=self.keep_project_on_failure,
+        )
+
+
+@dataclass
+class SignatureInfo:
+    """Information about a template signature for display in the UI."""
+
+    text: str = "The Plone Community"
+    url: str = "https://plone.org"
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "SignatureInfo":
+        """Build a :class:`SignatureInfo` from a raw config mapping.
+
+        :param data: The ``signature`` sub-mapping from a template's
+            ``cookieplone-config.json`` ``config.summary`` block. Missing keys
+            fall back to the class defaults.
+        :returns: A populated :class:`SignatureInfo`.
+        """
+        return cls(
+            text=data.get("text", cls.text),
+            url=data.get("url", cls.url),
+        )
+
+
+@dataclass
+class SummaryInfo:
+    """Information about the summary for display in the UI."""
+
+    enabled: bool = False
+    message: str = "Now, code it, create a git repository, push to your organization."
+    thanks: str = "Sorry for the convenience,"
+    signature: SignatureInfo = field(default_factory=SignatureInfo)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "SummaryInfo":
+        """Build a :class:`SummaryInfo` from a raw config mapping.
+
+        :param data: The ``config.summary`` mapping from a template's
+            ``cookieplone-config.json``. Missing keys fall back to the class
+            defaults; an empty mapping yields a disabled summary.
+        :returns: A populated :class:`SummaryInfo`.
+        """
+        return cls(
+            enabled=data.get("enabled", cls.enabled),
+            message=data.get("message", cls.message),
+            thanks=data.get("thanks", cls.thanks),
+            signature=SignatureInfo.from_dict(data.get("signature", {})),
         )

--- a/cookieplone/cli/__init__.py
+++ b/cookieplone/cli/__init__.py
@@ -20,6 +20,7 @@ from cookieplone.repository import get_template_options
 from cookieplone.utils import console
 from cookieplone.utils import files
 from cookieplone.utils import internal
+from cookieplone.utils import summary
 from copy import deepcopy
 from pathlib import Path
 from rich.prompt import Prompt
@@ -354,13 +355,15 @@ def cli(
         template_underlay=cookieplone_template.underlay or None,
     )
     try:
-        generate(gen_config)
+        path, state = generate(gen_config, return_state=True)
     except (GeneratorException, PreFlightException, VersionTooOldException) as exc:
         console.error(exc.message)
         raise typer.Exit(1)  # noQA:B904
     except Exception as exc:
         console.error(str(exc))
         raise typer.Exit(1)  # noQA:B904
+    else:
+        summary.display_summary_screen(path, cookieplone_template.title, state)
 
 
 def main():

--- a/cookieplone/config/merge.py
+++ b/cookieplone/config/merge.py
@@ -16,6 +16,7 @@ with a downstream one, applying the merge rules documented in issue #175:
   share an ``id``.  Group ``templates`` lists are replaced wholesale (not
   appended) so downstream can re-order or drop entries.
 - ``config.versions``: shallow merge, downstream wins per key.
+- ``config.summary``: shallow merge, downstream wins per key.
 - ``config.renderer``: downstream wins if set, otherwise upstream.
 - ``config.min_version``: ``max(upstream, downstream)`` via PEP 440 ordering.
 
@@ -103,6 +104,10 @@ def _merge_config_section(upstream: dict, downstream: dict) -> dict:
     versions = {**upstream.get("versions", {}), **downstream.get("versions", {})}
     if versions:
         merged["versions"] = versions
+
+    summary = {**upstream.get("summary", {}), **downstream.get("summary", {})}
+    if summary:
+        merged["summary"] = summary
 
     renderer = downstream.get("renderer") or upstream.get("renderer")
     if renderer:

--- a/cookieplone/config/schemas/repository_config.schema.json
+++ b/cookieplone/config/schemas/repository_config.schema.json
@@ -65,6 +65,21 @@
     "config": {
       "type": "object",
       "properties": {
+        "summary": {
+          "type": "object",
+          "properties": {
+            "enabled": {"type": "boolean"},
+            "message": {"type": "string"},
+            "thanks": {"type": "string"},
+            "signature": {
+              "type": "object",
+              "properties": {
+                "text": {"type": "string"},
+                "url": {"type": "string"}
+              }
+            }
+          }
+        },
         "versions": {
           "type": "object",
           "additionalProperties": {"type": "string"}

--- a/cookieplone/config/state.py
+++ b/cookieplone/config/state.py
@@ -85,6 +85,10 @@ class CookieploneState:
     :param versions: Version pinning dict from the config's ``versions`` mapping.
         Injected into ``data["versions"]`` so templates can access values via
         ``{{ versions.<key> }}``.
+    :param summary: The repository config's ``config.summary`` mapping driving
+        the post-generation summary screen (``enabled``, ``message``,
+        ``thanks``, ``signature``).  Populated from
+        :attr:`~cookieplone._types.RepositoryInfo.summary` during generation.
     """
 
     schema: dict[str, Any]
@@ -97,6 +101,7 @@ class CookieploneState:
     subtemplates: list[SubTemplate] = field(default_factory=list)
     template_id: str = ""
     versions: dict[str, str] = field(default_factory=dict)
+    summary: dict[str, Any] = field(default_factory=dict)
 
 
 def _parse_schema(context: dict[str, Any], version: str = "1.0") -> ParsedConfig:

--- a/cookieplone/generator/__init__.py
+++ b/cookieplone/generator/__init__.py
@@ -21,6 +21,8 @@ from cookieplone.utils import files
 from cookieplone.utils.console import quiet_mode
 from cookieplone.utils.cookiecutter import load_replay
 from pathlib import Path
+from typing import Literal
+from typing import overload
 
 import os
 import warnings
@@ -44,7 +46,19 @@ def _dump_answers(answers_: Answers, template_name: str, no_input: bool = False)
     return answers.write_answers(answers_, template_name, no_input)
 
 
-def generate(config: GenerateConfig) -> Path:
+@overload
+def generate(config: GenerateConfig, return_state: Literal[False] = False) -> Path: ...
+
+
+@overload
+def generate(
+    config: GenerateConfig, return_state: Literal[True]
+) -> tuple[Path, CookieploneState]: ...
+
+
+def generate(
+    config: GenerateConfig, return_state: bool = False
+) -> Path | tuple[Path, CookieploneState]:
     """Generate a project from a cookieplone template.
 
     Resolves the repository, builds the run state (including any replay or
@@ -53,7 +67,10 @@ def generate(config: GenerateConfig) -> Path:
 
     :param config: A :class:`~cookieplone._types.GenerateConfig` holding all
         generation options.
-    :returns: Path to the generated project directory.
+    :param return_state: When ``True``, return the
+        :class:`~cookieplone.config.CookieploneState` alongside the output path.
+    :returns: Path to the generated project directory, or a
+        ``(Path, CookieploneState)`` tuple when *return_state* is ``True``.
     :raises exc.InvalidModeException: When incompatible options are combined
         (e.g. *replay* with *no_input* or *extra_context*).
     :raises RepositoryException: When the repository cannot be resolved.
@@ -114,6 +131,10 @@ def generate(config: GenerateConfig) -> Path:
         replay_context=context_from_replayfile if config.replay else None,
         global_versions=effective_versions,
     )
+    # The post-generation summary screen is configured at the repository level
+    # (``cookieplone-config.json`` ``config.summary``), surfaced here on the
+    # run state so the CLI can render it after generation completes.
+    state.summary = repository_info.summary
 
     run_config = config.to_run_config()
     dump_location = None
@@ -133,7 +154,7 @@ def generate(config: GenerateConfig) -> Path:
     except Exception as e:
         raise GeneratorException(message=str(e), state=state, original=e)  # noQA:B904
     else:
-        return Path(result)
+        return Path(result) if not return_state else (Path(result), state)
     finally:
         if config.dump_answers:
             path = _dump_answers(state.answers, config.template_name, config.no_input)

--- a/cookieplone/repository.py
+++ b/cookieplone/repository.py
@@ -1033,10 +1033,12 @@ def _populate_repository_metadata(
     checkout: str,
     password: str,
     overlay_cleanup: list[Path],
-) -> tuple[dict[str, str], str, list[Path], list[Path], Path, Path]:
-    """Populate global versions, renderer, and handle overlay from repo config."""
+) -> tuple[dict[str, str], str, dict[str, Any], list[Path], list[Path], Path, Path]:
+    """Populate global versions, renderer, summary, and handle overlay from
+    repo config."""
     global_versions: dict[str, str] = {}
     renderer: str = ""
+    summary: dict[str, Any] = {}
     extends_cleanup: list[Path] = []
     upstream_repos_out: list[Path] = []
 
@@ -1044,6 +1046,7 @@ def _populate_repository_metadata(
         return (
             global_versions,
             renderer,
+            summary,
             extends_cleanup,
             upstream_repos_out,
             base_repo_dir,
@@ -1056,6 +1059,7 @@ def _populate_repository_metadata(
         )
         global_versions = repo_config.get("config", {}).get("versions", {})
         renderer = repo_config.get("config", {}).get("renderer", "")
+        summary = repo_config.get("config", {}).get("summary", {})
         _check_min_version(repo_config.get("config", {}))
         cache_entry = _RESOLUTION_CACHE.get(str(config_root.resolve()))
         if cache_entry is not None:
@@ -1087,6 +1091,7 @@ def _populate_repository_metadata(
     return (
         global_versions,
         renderer,
+        summary,
         extends_cleanup,
         upstream_repos_out,
         base_repo_dir,
@@ -1168,6 +1173,7 @@ def get_repository(
     (
         global_versions,
         renderer,
+        summary,
         extends_cleanup,
         upstream_repos_out,
         base_repo_dir,
@@ -1212,6 +1218,7 @@ def get_repository(
         config_dict=config_dict,
         global_versions=global_versions,
         renderer=renderer,
+        summary=summary,
         cleanup_paths=cleanup_paths,
         upstream_repos=upstream_repos_out,
     )

--- a/cookieplone/utils/console.py
+++ b/cookieplone/utils/console.py
@@ -327,3 +327,23 @@ def quiet_mode():
         yield
     finally:
         disable_quiet_mode()
+
+
+def summary_screen(
+    template_title: str, title: str, path: Path, info: t.SummaryInfo
+) -> None:
+    """Print a summary of the generated codebase."""
+    msg = f"""
+        [bold blue]{title}[/bold blue]
+
+        {info.message}
+
+        {info.thanks}
+        {info.signature.text}
+    """
+    panel(
+        title=f"New {template_title} was generated",
+        subtitle=f"Located at {path}",
+        msg=msg,
+        url=info.signature.url,
+    )

--- a/cookieplone/utils/summary.py
+++ b/cookieplone/utils/summary.py
@@ -1,0 +1,43 @@
+from cookieplone import _types as t
+from cookieplone.config.state import CookieploneState
+from cookieplone.utils import console
+from pathlib import Path
+
+
+def summary_info(state: CookieploneState | None) -> t.SummaryInfo:
+    """Resolve the post-generation summary configuration.
+
+    Reads the ``config.summary`` block from the template's
+    ``cookieplone-config.json`` (surfaced on
+    :attr:`~cookieplone.config.CookieploneState.summary`) and converts it into a
+    :class:`~cookieplone._types.SummaryInfo`.  When no summary config is present
+    the returned value is disabled by default.
+
+    :param state: The generation state, or ``None`` when unavailable.
+    :returns: The resolved :class:`~cookieplone._types.SummaryInfo`.
+    """
+    raw = state.summary if state else {}
+    return t.SummaryInfo.from_dict(raw)
+
+
+def display_summary_screen(
+    path: Path, template_title: str, state: CookieploneState | None
+) -> None:
+    """Render the post-generation summary screen when it is enabled.
+
+    :param path: Path to the generated project directory.
+    :param template_title: Human-readable title of the template that was used.
+    :param state: The generation state, or ``None`` when unavailable.
+    """
+    summary_ = summary_info(state)
+    if not summary_.enabled:
+        return
+    title = "Generation successful"
+    if state and state.answers:
+        title = state.answers.answers.get("title", title)
+    console.summary_screen(
+        template_title=template_title,
+        title=title,
+        path=path,
+        info=summary_,
+    )

--- a/docs/src/reference/repository-config.md
+++ b/docs/src/reference/repository-config.md
@@ -4,7 +4,7 @@ myst:
     "description": "Full specification for the cookieplone-config.json repository configuration file."
     "property=og:description": "Full specification for the cookieplone-config.json repository configuration file."
     "property=og:title": "Repository configuration (cookieplone-config.json)"
-    "keywords": "Cookieplone, cookieplone-config.json, repository, templates, groups, versions, extends"
+    "keywords": "Cookieplone, cookieplone-config.json, repository, templates, groups, versions, extends, summary"
 ---
 
 # Repository configuration (`cookieplone-config.json`)
@@ -133,6 +133,15 @@ Global configuration shared across all templates in the repository.
 {
   "config": {
     "min_version": "2.0.0a2",
+    "summary": {
+      "enabled": true,
+      "message": "Now, code it, create a git repository, push to your organization.",
+      "thanks": "Sorry for the convenience,",
+      "signature": {
+        "text": "The Plone Community",
+        "url": "https://plone.org"
+      }
+    },
     "versions": {
       "gha_version_checkout": "v6",
       "gha_version_setup_node": "v4",
@@ -200,6 +209,38 @@ Please upgrade:  uvx --no-cache cookieplone@2.0.0a2
 
 When the key is absent or empty, no version check is performed (backwards compatible with existing repositories).
 
+### `config.summary`
+
+Configures the summary screen shown after a codebase is generated.
+This is rendered automatically once generation completes, so templates no longer need to print a closing panel from their own post-generation hooks.
+
+```json
+{
+  "config": {
+    "summary": {
+      "enabled": true,
+      "message": "Now, code it, create a git repository, push to your organization.",
+      "thanks": "Sorry for the convenience,",
+      "signature": {
+        "text": "The Plone Community",
+        "url": "https://plone.org"
+      }
+    }
+  }
+}
+```
+
+| Key | Type | Required | Default | Description |
+|-----|------|----------|---------|-------------|
+| `enabled` | boolean | no | `false` | When `true`, the summary screen is shown after generation. |
+| `message` | string | no | `"Now, code it, create a git repository, push to your organization."` | Body text shown in the panel. |
+| `thanks` | string | no | `"Sorry for the convenience,"` | Closing line shown above the signature. |
+| `signature.text` | string | no | `"The Plone Community"` | Signature label shown below the message. |
+| `signature.url` | string | no | `"https://plone.org"` | URL associated with the signature. |
+
+The summary screen is disabled by default: a repository opts in by setting `enabled` to `true`.
+Any omitted key falls back to the default shown above, so a repository can override just the `signature` while keeping the standard message.
+
 (repo-extends)=
 ## `extends`
 
@@ -249,6 +290,7 @@ When a downstream declares `extends`, Cookieplone clones the upstream and merges
 | `templates` | Keyed union; a downstream entry merges per-field with the upstream entry of the same `id`. Downstream wins per field; fields the downstream omits inherit from upstream. When the downstream entry supplies `path`, its template directory is overlaid on top of upstream's at render time. |
 | `groups` | Keyed union; a downstream group entry replaces the upstream entry with the same `id`. The `templates` list inside a group is **replaced** wholesale, not merged. |
 | `config.versions` | Shallow merge, downstream wins per key. |
+| `config.summary` | Shallow merge, downstream wins per key. |
 | `config.renderer` | Downstream wins if set; otherwise falls back to upstream. |
 | `config.min_version` | Stricter wins: `max(upstream.min_version, downstream.min_version)` using PEP 440 ordering. |
 

--- a/news/204.feature
+++ b/news/204.feature
@@ -1,0 +1,1 @@
+Added an optional post-generation summary screen, configurable via the `config.summary` block of `cookieplone-config.json`. @ericof

--- a/tests/_resources/config/cookieplone-config-no-summary.json
+++ b/tests/_resources/config/cookieplone-config-no-summary.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.0",
+  "title": "Plone Community Templates (no summary)",
+  "description": "Repository config fixture without a config.summary block",
+  "groups": {
+    "projects": {
+      "title": "Projects",
+      "description": "Generators that create a new Plone project",
+      "templates": [
+        "project"
+      ],
+      "hidden": false
+    }
+  },
+  "templates": {
+    "project": {
+      "path": "./templates/projects/monorepo",
+      "title": "Volto Project",
+      "description": "Create a new Plone project that uses the Volto frontend",
+      "hidden": false
+    }
+  },
+  "config": {
+    "versions": {
+      "gha_version_checkout": "v6"
+    }
+  }
+}

--- a/tests/_resources/config/cookieplone-config.json
+++ b/tests/_resources/config/cookieplone-config.json
@@ -197,6 +197,15 @@
     }
   },
   "config": {
+    "summary": {
+      "enabled": true,
+      "message": "Your Plone project is ready to roll!",
+      "thanks": "Thanks for choosing Plone,",
+      "signature": {
+        "text": "The Plone Community Team",
+        "url": "https://plone.org/community"
+      }
+    },
     "versions": {
       "devops_traefik_version": "v2.11",
       "devops_zeo_version": "6.0.0",

--- a/tests/config/test_summary_config.py
+++ b/tests/config/test_summary_config.py
@@ -1,0 +1,177 @@
+"""Tests for the ``config.summary`` block of the repository config.
+
+Covers parsing the post-generation summary settings from
+``cookieplone-config.json`` (including default values when the block is
+absent), schema validation, and the ``extends`` extension mechanism that
+merges a downstream summary on top of an upstream one.
+"""
+
+from cookieplone._types import SignatureInfo
+from cookieplone._types import SummaryInfo
+from cookieplone.config.merge import merge_repo_configs
+from cookieplone.config.schemas import validate_repository_config
+from pathlib import Path
+
+import json
+import pytest
+
+
+RESOURCES = Path(__file__).parent.parent / "_resources" / "config"
+
+UPSTREAM_DIR = Path("upstream")
+DOWNSTREAM_DIR = Path("downstream")
+
+
+def _load(name: str) -> dict:
+    """Load a repository config fixture by file name."""
+    return json.loads((RESOURCES / name).read_text())
+
+
+def _summary_of(config: dict) -> SummaryInfo:
+    """Resolve a :class:`SummaryInfo` from a repository config dict, mirroring
+    how :func:`cookieplone.repository._populate_repository_metadata` reads it."""
+    raw = config.get("config", {}).get("summary", {})
+    return SummaryInfo.from_dict(raw)
+
+
+def _merge(upstream: dict, downstream: dict) -> dict:
+    """Merge two repository configs the way the ``extends`` mechanism does."""
+    return merge_repo_configs(
+        upstream,
+        downstream,
+        upstream_repo_dir=UPSTREAM_DIR,
+        downstream_repo_dir=DOWNSTREAM_DIR,
+    )
+
+
+def _repo_with_summary(summary: dict | None) -> dict:
+    """Build a minimal valid repository config, optionally with a summary."""
+    config: dict = {}
+    if summary is not None:
+        config["summary"] = summary
+    return {
+        "version": "1.0",
+        "title": "Templates",
+        "groups": {
+            "main": {
+                "title": "Main",
+                "description": "Main templates",
+                "templates": ["project"],
+            }
+        },
+        "templates": {"project": {"path": ".", "title": "Project", "description": "D"}},
+        "config": config,
+    }
+
+
+class TestSummaryParsing:
+    """Parsing ``config.summary`` from ``cookieplone-config.json``."""
+
+    def test_configured_values_are_read(self):
+        """The fixture with a summary block yields its configured values."""
+        info = _summary_of(_load("cookieplone-config.json"))
+        assert info == SummaryInfo(
+            enabled=True,
+            message="Your Plone project is ready to roll!",
+            thanks="Thanks for choosing Plone,",
+            signature=SignatureInfo(
+                text="The Plone Community Team",
+                url="https://plone.org/community",
+            ),
+        )
+
+    def test_defaults_when_block_absent(self):
+        """A config without a summary block falls back to all defaults."""
+        info = _summary_of(_load("cookieplone-config-no-summary.json"))
+        assert info == SummaryInfo()
+        assert info.enabled is False
+
+    @pytest.mark.parametrize(
+        "attr,expected",
+        [
+            ("enabled", False),
+            (
+                "message",
+                "Now, code it, create a git repository, push to your organization.",
+            ),
+            ("thanks", "Sorry for the convenience,"),
+        ],
+    )
+    def test_default_scalar_values(self, attr, expected):
+        """Each scalar default is applied when the summary block is missing."""
+        info = _summary_of(_load("cookieplone-config-no-summary.json"))
+        assert getattr(info, attr) == expected
+
+    def test_default_signature(self):
+        """The default signature is applied when the summary block is missing."""
+        info = _summary_of(_load("cookieplone-config-no-summary.json"))
+        assert info.signature == SignatureInfo(
+            text="The Plone Community", url="https://plone.org"
+        )
+
+
+class TestSummarySchema:
+    """Schema validation of the ``config.summary`` block."""
+
+    @pytest.mark.parametrize(
+        "name",
+        ["cookieplone-config.json", "cookieplone-config-no-summary.json"],
+    )
+    def test_fixtures_validate(self, name):
+        """Both summary fixtures pass repository config validation."""
+        valid, errors = validate_repository_config(_load(name))
+        assert valid is True, errors
+
+    def test_partial_summary_validates(self):
+        """A summary block with only some keys is valid."""
+        valid, errors = validate_repository_config(
+            _repo_with_summary({"enabled": True})
+        )
+        assert valid is True, errors
+
+    def test_enabled_must_be_boolean(self):
+        """A non-boolean ``enabled`` is rejected by the schema."""
+        valid, _errors = validate_repository_config(
+            _repo_with_summary({"enabled": "yes"})
+        )
+        assert valid is False
+
+
+class TestSummaryExtendsMerge:
+    """The ``extends`` mechanism merges summary downstream-over-upstream."""
+
+    def test_downstream_inherits_upstream_summary(self):
+        """A downstream without a summary inherits the upstream's."""
+        upstream = _repo_with_summary({"enabled": True, "message": "Upstream message"})
+        downstream = {"version": "1.0", "title": "Downstream", "extends": "gh:up"}
+        merged = _merge(upstream, downstream)
+        info = _summary_of(merged)
+        assert info.enabled is True
+        assert info.message == "Upstream message"
+
+    def test_downstream_overrides_per_key(self):
+        """Downstream summary keys win; upstream fills the omitted keys."""
+        upstream = _repo_with_summary({
+            "enabled": True,
+            "message": "Upstream message",
+            "signature": {"text": "Upstream", "url": "https://up.example"},
+        })
+        downstream = {
+            "version": "1.0",
+            "title": "Downstream",
+            "extends": "gh:up",
+            "config": {"summary": {"message": "Downstream message"}},
+        }
+        merged = _merge(upstream, downstream)
+        summary = merged["config"]["summary"]
+        assert summary["message"] == "Downstream message"
+        # Untouched keys come from upstream.
+        assert summary["enabled"] is True
+        assert summary["signature"] == {"text": "Upstream", "url": "https://up.example"}
+
+    def test_no_summary_either_side_yields_defaults(self):
+        """When neither side configures a summary, defaults apply."""
+        upstream = _repo_with_summary(None)
+        downstream = {"version": "1.0", "title": "Downstream", "extends": "gh:up"}
+        merged = _merge(upstream, downstream)
+        assert _summary_of(merged) == SummaryInfo()

--- a/tests/utils/test_summary.py
+++ b/tests/utils/test_summary.py
@@ -1,0 +1,108 @@
+"""Tests for :mod:`cookieplone.utils.summary`."""
+
+from cookieplone import _types as t
+from cookieplone.config import Answers
+from cookieplone.config import CookieploneState
+from cookieplone.utils import summary
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _state(*, summary_cfg: dict | None = None, answers: Answers | None = None):
+    """Build a minimal :class:`CookieploneState` for summary tests."""
+    return CookieploneState(
+        schema={},
+        data={},
+        summary=summary_cfg or {},
+        answers=answers if answers is not None else Answers(),
+    )
+
+
+@pytest.fixture
+def mock_screen(monkeypatch) -> MagicMock:
+    """Patch ``console.summary_screen`` as referenced by the summary module."""
+    mock = MagicMock()
+    monkeypatch.setattr("cookieplone.utils.summary.console.summary_screen", mock)
+    return mock
+
+
+class TestSummaryInfo:
+    """Tests for :func:`cookieplone.utils.summary.summary_info`."""
+
+    def test_none_state_returns_disabled_default(self):
+        """A missing state yields the disabled default summary."""
+        info = summary.summary_info(None)
+        assert info == t.SummaryInfo()
+        assert info.enabled is False
+
+    def test_empty_state_summary_returns_default(self):
+        """A state with no summary config yields the defaults."""
+        assert summary.summary_info(_state(summary_cfg={})) == t.SummaryInfo()
+
+    def test_reads_values_from_state(self):
+        """A populated ``state.summary`` is converted into a SummaryInfo."""
+        state = _state(
+            summary_cfg={
+                "enabled": True,
+                "message": "M",
+                "thanks": "T",
+                "signature": {"text": "X", "url": "https://x.example"},
+            }
+        )
+        assert summary.summary_info(state) == t.SummaryInfo(
+            enabled=True,
+            message="M",
+            thanks="T",
+            signature=t.SignatureInfo(text="X", url="https://x.example"),
+        )
+
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_enabled_flag_round_trips(self, enabled):
+        """The ``enabled`` flag is read straight from the state summary."""
+        info = summary.summary_info(_state(summary_cfg={"enabled": enabled}))
+        assert info.enabled is enabled
+
+
+class TestDisplaySummaryScreen:
+    """Tests for :func:`cookieplone.utils.summary.display_summary_screen`."""
+
+    def test_disabled_skips_render(self, mock_screen):
+        """When the summary is disabled nothing is rendered."""
+        summary.display_summary_screen(
+            Path("/out"), "Volto Project", _state(summary_cfg={"enabled": False})
+        )
+        mock_screen.assert_not_called()
+
+    def test_none_state_skips_render(self, mock_screen):
+        """A missing state resolves to disabled and renders nothing."""
+        summary.display_summary_screen(Path("/out"), "Volto Project", None)
+        mock_screen.assert_not_called()
+
+    def test_enabled_renders_with_answer_title(self, mock_screen):
+        """An enabled summary uses the ``title`` answer as the screen title."""
+        state = _state(
+            summary_cfg={"enabled": True},
+            answers=Answers(answers={"title": "My Site"}),
+        )
+        summary.display_summary_screen(Path("/out"), "Volto Project", state)
+        mock_screen.assert_called_once()
+        kwargs = mock_screen.call_args.kwargs
+        assert kwargs["title"] == "My Site"
+        assert kwargs["template_title"] == "Volto Project"
+        assert kwargs["path"] == Path("/out")
+        assert kwargs["info"].enabled is True
+
+    def test_default_title_without_title_answer(self, mock_screen):
+        """Without a ``title`` answer the default screen title is used."""
+        state = _state(summary_cfg={"enabled": True}, answers=Answers(answers={}))
+        summary.display_summary_screen(Path("/out"), "Volto Project", state)
+        assert mock_screen.call_args.kwargs["title"] == "Generation successful"
+
+    def test_default_title_without_answers(self, mock_screen):
+        """When ``state.answers`` is missing the default title is used."""
+        state = _state(summary_cfg={"enabled": True})
+        state.answers = None  # type: ignore[assignment]
+        summary.display_summary_screen(Path("/out"), "Volto Project", state)
+        assert mock_screen.call_args.kwargs["title"] == "Generation successful"


### PR DESCRIPTION
## Summary

Adds an optional **post-generation summary screen** rendered automatically after a project is generated, so templates no longer need to print a closing panel from their own post-generation hooks.

Closes #204

## Configuration

The screen is configured via a new `config.summary` block in the repository `cookieplone-config.json`:

```json
{
  "config": {
    "summary": {
      "enabled": true,
      "message": "Now, code it, create a git repository, push to your organization.",
      "thanks": "Sorry for the convenience,",
      "signature": {
        "text": "The Plone Community",
        "url": "https://plone.org"
      }
    }
  }
}
```

| Key | Type | Default | Description |
|-----|------|---------|-------------|
| `enabled` | boolean | `false` | Show the summary screen after generation. |
| `message` | string | `"Now, code it, create a git repository, push to your organization."` | Panel body text. |
| `thanks` | string | `"Sorry for the convenience,"` | Closing line above the signature. |
| `signature.text` | string | `"The Plone Community"` | Signature label. |
| `signature.url` | string | `"https://plone.org"` | Signature URL. |

Disabled by default; omitted keys fall back to the defaults above.

## Implementation

- `config.summary` is read into `RepositoryInfo.summary`, surfaced on the run state, and rendered by the new `cookieplone.utils.summary` module.
- Participates in the `extends` merge: shallow merge, downstream wins per key.
- `generate()` is now typed with `@overload` so `return_state=True` narrows the return to `(Path, CookieploneState)`.

## Tests

- `tests/config/test_summary_config.py` — parsing, defaults, schema validation, and `extends` merge behavior.
- `tests/utils/test_summary.py` — 100% coverage of `cookieplone/utils/summary.py`.
- Full suite: 1041 passed.

## Docs

- `docs/src/reference/repository-config.md` — new `config.summary` section, config example, and merge-rules row.