### PR TITLE
Display an error screen when the template repository is not usable

### DIFF
--- a/cookieplone/cli.py
+++ b/cookieplone/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
+from cookiecutter.exceptions import RepositoryCloneFailed, RepositoryNotFound
 from rich.prompt import Prompt
 
 from cookieplone import _types as t
@@ -54,6 +55,25 @@ def parse_boolean(value: str) -> bool:
     return value.lower() in ("1", "yes", "y")
 
 
+def get_repository_or_exit(repository: str, tag: str) -> Path:
+    """Resolve the base repository, displaying an error screen on failure.
+
+    :param repository: Repository URL, abbreviation, or local path.
+    :param tag: Repository tag, branch, or commit to be used.
+    :returns: Path to the local checkout of the repository.
+    :raises typer.Exit: If no valid repository is found for the given tag.
+    """
+    try:
+        return get_base_repository(repository, tag)
+    except (RepositoryNotFound, RepositoryCloneFailed) as exc:
+        console.error_screen(
+            f"Repository [bold]{repository}[/bold] with tag [bold]{tag}[/bold]"
+            " not found.\n\n"
+            "Please, try to use a newer version of cookieplone or use another tag."
+        )
+        raise typer.Exit(1) from exc
+
+
 def prompt_for_template(base_path: Path, all_: bool = False) -> t.CookieploneTemplate:
     """Parse cookiecutter.json in base_path and prompt user to choose."""
     templates = get_template_options(base_path, all_)
@@ -73,7 +93,7 @@ def cli(
         data.OptionalPath,
         typer.Option("--output-dir", "-o", help="Where to generate the code."),
     ] = None,
-    tag: Annotated[str, typer.Option(help="Tag.")] = "main",
+    tag: Annotated[str, typer.Option(help="Tag.")] = "20260810.1",
     info: Annotated[
         bool,
         typer.Option(
@@ -158,7 +178,7 @@ def cli(
         console.info_screen(repository=repository, passwd=passwd, tag=tag)
         raise typer.Exit()
 
-    repo_path = get_base_repository(repository, tag)
+    repo_path = get_repository_or_exit(repository, tag)
     if not template:
         # Display template options
         cookieplone_template = prompt_for_template(repo_path)

--- a/cookieplone/utils/console.py
+++ b/cookieplone/utils/console.py
@@ -174,6 +174,23 @@ def welcome_screen(templates: list[t.CookieploneTemplate] | None = None):
     base_print(panel)
 
 
+def error_screen(msg: str):
+    """Display an error message inside the cookieplone panel.
+
+    :param msg: Error message to be displayed. Rich markup is supported.
+    """
+    banner = choose_banner()
+    items = [
+        Align.center(f"[bold blue]{banner}[/bold blue]"),
+        Align.center(f"[red]{msg}[/red]"),
+    ]
+    panel = Panel(
+        Group(*items),
+        title="cookieplone",
+    )
+    base_print(panel)
+
+
 def version_screen():
     """Print version information."""
     base_print(version_info())

--- a/news/210.feature
+++ b/news/210.feature
@@ -1,0 +1,1 @@
+Display an error screen, instead of a traceback, when the template repository cannot be used: either it is not found for the given tag, or it has no `cookiecutter.json` file at its root. @ericof

--- a/news/210.internal
+++ b/news/210.internal
@@ -1,0 +1,1 @@
+Pin the default template repository tag to `20260810.1`. @ericof

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,9 @@
+from unittest.mock import patch
+
 import pytest
+import typer
 from click.exceptions import BadParameter
+from cookiecutter.exceptions import RepositoryCloneFailed, RepositoryNotFound
 
 from cookieplone import cli
 
@@ -43,3 +47,23 @@ def test_validate_extra_context_fail(value: list[str] | None, expected: str):
     with pytest.raises(BadParameter) as exc:
         func(value)
     assert expected in str(exc)
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        RepositoryNotFound("No cookiecutter.json found"),
+        RepositoryCloneFailed("The foo branch of repository bar could not found"),
+    ],
+)
+@patch("cookieplone.cli.console.error_screen")
+@patch("cookieplone.cli.get_base_repository")
+def test_cli_repository_error_screen(
+    mock_get_base_repository, mock_error_screen, exception: Exception
+):
+    """Repository failures display an error screen and exit with status 1."""
+    mock_get_base_repository.side_effect = exception
+    with pytest.raises(typer.Exit) as exc:
+        cli.cli()
+    assert exc.value.exit_code == 1
+    mock_error_screen.assert_called_once()

--- a/tests/utils/test_console.py
+++ b/tests/utils/test_console.py
@@ -49,3 +49,16 @@ def test_choose_banner(set_console_width, width: int, banner: str):
 def test_prints(mock_print, func, msg, style, color):
     func(msg)
     mock_print.assert_called_once_with(msg, style, color)
+
+
+@patch("cookieplone.utils.console.base_print")
+def test_error_screen(mock_base_print):
+    from rich.console import Console
+
+    console.error_screen("Repository not found")
+    mock_base_print.assert_called_once()
+    panel = mock_base_print.call_args[0][0]
+    assert panel.title == "cookieplone"
+    recorder = Console(width=120, record=True)
+    recorder.print(panel)
+    assert "Repository not found" in recorder.export_text()


### PR DESCRIPTION
## What

Display an error screen, instead of a traceback, when the template repository cannot be used, and pin the default `--tag` for the 1.x series.

## Why

`cookieplone` resolved the base repository with a bare call to `get_base_repository`, so any failure surfaced as a raw `cookiecutter` traceback.

Two distinct failures reach that call:

- `RepositoryNotFound` — no candidate directory contains a `cookiecutter.json` file at its root (`determine_repo_dir` checks `repository_has_cookiecutter_json` for each candidate before raising).
- `RepositoryCloneFailed` — the clone succeeded but the requested tag does not exist (`cookiecutter.vcs.clone` raises this on a failed checkout).

The second is the case the error message actually steers the user toward ("use another tag"), so handling only the first would leave that advice unreachable.

## How

- New `get_repository_or_exit` helper in `cookieplone/cli.py` wraps `get_base_repository`, catches both exceptions, renders an error screen, and exits with status `1`. Keeping the handling in a helper also holds `cli` under the McCabe complexity limit enforced by ruff.
- New `console.error_screen` renders a message inside the standard cookieplone panel.
- Default `--tag` pinned to `20260810.1`, an existing tag of `plone/cookieplone-templates`.

## Tests

- `tests/test_cli.py` — parametrized over `RepositoryNotFound` and `RepositoryCloneFailed`; asserts exit code `1` and that the error screen is displayed.
- `tests/utils/test_console.py` — renders the panel through a recording `rich.Console` and asserts its title and message.

Verified the `RepositoryCloneFailed` case fails without the fix by temporarily narrowing the `except` clause, then restoring it.

Full suite: 280 passed. `make lint` clean.

## Notes

Targets the `1.x` maintenance branch.

Refs #210
